### PR TITLE
Optimize Simulated Target for INST

### DIFF
--- a/openc3/lib/openc3/utilities/simulated_target.rb
+++ b/openc3/lib/openc3/utilities/simulated_target.rb
@@ -65,6 +65,14 @@ module OpenC3
       raise "Error: read must be implemented by subclass"
     end
 
+    def tick_period_seconds
+      return 0.01 # Override this method to optimize
+    end
+
+    def tick_increment
+      return 1 # Override this method to optimize
+    end
+
     protected
 
     def set_rate(packet_name, rate)


### PR DESCRIPTION
Greatly improves CPU utilization used by INST sim targets.  
Reduces runs from 100Hz to 10Hz
Removes IO of reading Position/Attitude Files