### PR TITLE
Support Selinux

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -24,7 +24,7 @@ services:
     image: "${OPENC3_REGISTRY}/openc3inc/openc3-minio:${OPENC3_TAG}"
     volumes:
       - "openc3-minio-v:/data"
-      - "./cacert.pem:/devel/cacert.pem"
+      - "./cacert.pem:/devel/cacert.pem:z"
     command: ["server", "/data"]
     restart: "unless-stopped"
     environment:
@@ -39,8 +39,8 @@ services:
     image: "${OPENC3_REGISTRY}/openc3inc/openc3-redis:${OPENC3_TAG}"
     volumes:
       - "openc3-redis-v:/data"
-      - "./cacert.pem:/devel/cacert.pem"
-      - "./openc3-redis/users.acl:/config/users.acl"
+      - "./cacert.pem:/devel/cacert.pem:z"
+      - "./openc3-redis/users.acl:/config/users.acl:z"
     restart: "unless-stopped"
     environment:
       SSL_CERT_FILE: "/devel/cacert.pem"
@@ -51,8 +51,8 @@ services:
   openc3-redis-ephemeral:
     image: "${OPENC3_REGISTRY}/openc3inc/openc3-redis:${OPENC3_TAG}"
     volumes:
-      - "./cacert.pem:/devel/cacert.pem"
-      - "./openc3-redis/users.acl:/config/users.acl"
+      - "./cacert.pem:/devel/cacert.pem:z"
+      - "./openc3-redis/users.acl:/config/users.acl:z"
     restart: "unless-stopped"
     command: ["redis-server", "/config/redis_ephemeral.conf"]
     environment:
@@ -70,7 +70,7 @@ services:
       - "openc3-minio"
     volumes:
       - "openc3-gems-v:/gems"
-      - "./cacert.pem:/devel/cacert.pem"
+      - "./cacert.pem:/devel/cacert.pem:z"
     environment:
       - "RAILS_ENV=production"
       - "GEM_HOME=/gems"
@@ -86,7 +86,7 @@ services:
       - "openc3-minio"
     volumes:
       - "openc3-gems-v:/gems:ro"
-      - "./cacert.pem:/devel/cacert.pem"
+      - "./cacert.pem:/devel/cacert.pem:z"
     environment:
       - "RAILS_ENV=production"
       - "GEM_HOME=/gems"
@@ -115,8 +115,8 @@ services:
   openc3-traefik:
     image: "${OPENC3_REGISTRY}/openc3inc/openc3-traefik:${OPENC3_TAG}"
     volumes:
-      - "./cacert.pem:/devel/cacert.pem"
-      - "./openc3-traefik/traefik.yaml:/etc/traefik/traefik.yaml"
+      - "./cacert.pem:/devel/cacert.pem:z"
+      - "./openc3-traefik/traefik.yaml:/etc/traefik/traefik.yaml:z"
       # - "./openc3-traefik/traefik-allow-http.yaml:/etc/traefik/traefik.yaml"
       # - "./openc3-traefik/traefik-ssl.yaml:/etc/traefik/traefik.yaml"
       # - "./openc3-traefik/traefik-letsencrypt.yaml:/etc/traefik/traefik.yaml"
@@ -148,7 +148,7 @@ services:
       - "openc3-minio"
     volumes:
       - "openc3-gems-v:/gems"
-      - "./cacert.pem:/devel/cacert.pem"
+      - "./cacert.pem:/devel/cacert.pem:z"
     environment:
       - "GEM_HOME=/gems"
     env_file:


### PR DESCRIPTION
Fixes Rootless podman for versions 5.0.5+ (and probably any linux with SELinux)