### PR TITLE
Implement OpenTelemetry tracing

### DIFF
--- a/openc3-cmd-tlm-api/config.ru
+++ b/openc3-cmd-tlm-api/config.ru
@@ -8,3 +8,4 @@ use Prometheus::Middleware::Collector
 use Prometheus::Middleware::Exporter, {:path => '/openc3-api/metrics'}
 
 run Rails.application
+Rails.application.load_server

--- a/openc3-cmd-tlm-api/config/application.rb
+++ b/openc3-cmd-tlm-api/config/application.rb
@@ -43,6 +43,17 @@ module CmdTlmApi
 
     Rails.backtrace_cleaner.remove_silencers!
 
+
     OpenC3::Logger.microservice_name = 'CMD__TLM__API'
+
+    require 'openc3/utilities/open_telemetry'
+    OpenC3.setup_open_telemetry('CMD__TLM__API', true)
+    if OpenC3.otel_enabled
+      require 'opentelemetry/instrumentation/rack/middlewares/tracer_middleware'
+      config.middleware.insert_before(
+        0,
+        OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
+      )
+    end
   end
 end

--- a/openc3-script-runner-api/config.ru
+++ b/openc3-script-runner-api/config.ru
@@ -8,3 +8,4 @@ use Prometheus::Middleware::Collector
 use Prometheus::Middleware::Exporter, {:path => '/script-api/metrics'}
 
 run Rails.application
+Rails.application.load_server

--- a/openc3-script-runner-api/config/application.rb
+++ b/openc3-script-runner-api/config/application.rb
@@ -42,5 +42,14 @@ module ScriptRunnerApi
     config.action_cable.mount_path = '/script-api/cable'
 
     OpenC3::Logger.microservice_name = 'SCRIPT__RUNNER__API'
+
+    require 'openc3/utilities/open_telemetry'
+    OpenC3.setup_open_telemetry('SCRIPT__RUNNER__API', true)
+    if OpenC3.otel_enabled
+      config.middleware.insert_before(
+        0,
+        OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
+      )
+    end
   end
 end

--- a/openc3/lib/openc3/microservices/microservice.rb
+++ b/openc3/lib/openc3/microservices/microservice.rb
@@ -25,6 +25,7 @@ OpenC3.require_file 'openc3/utilities/zip'
 OpenC3.require_file 'openc3/utilities/store'
 OpenC3.require_file 'openc3/utilities/s3'
 OpenC3.require_file 'openc3/utilities/sleeper'
+OpenC3.require_file 'openc3/utilities/open_telemetry'
 OpenC3.require_file 'openc3/models/microservice_model'
 OpenC3.require_file 'openc3/models/microservice_status_model'
 OpenC3.require_file 'tmpdir'
@@ -84,6 +85,8 @@ module OpenC3
       @metric = Metric.new(microservice: @name, scope: @scope)
       Logger.microservice_name = @name
       Logger.tag = @name + "__openc3.log"
+
+      OpenC3.setup_open_telemetry(@name, false)
 
       # Create temp folder for this microservice
       @temp_dir = Dir.mktmpdir

--- a/openc3/lib/openc3/topics/command_topic.rb
+++ b/openc3/lib/openc3/topics/command_topic.rb
@@ -18,6 +18,7 @@
 # All Rights Reserved
 
 require 'openc3/topics/topic'
+require 'openc3/utilities/open_telemetry'
 
 module OpenC3
   class CommandTopic < Topic
@@ -41,6 +42,7 @@ module OpenC3
       # Save the existing cmd_params Hash and JSON generate before writing to the topic
       cmd_params = command['cmd_params']
       command['cmd_params'] = JSON.generate(command['cmd_params'].as_json(:allow_nan => true))
+      OpenC3.inject_context(command)
       cmd_id = Topic.write_topic("{#{scope}__CMD}TARGET__#{command['target_name']}", command, '*', 100)
       # TODO: This timeout is fine for most but can we get the write_timeout from the interface here?
       time = Time.now

--- a/openc3/lib/openc3/utilities/open_telemetry.rb
+++ b/openc3/lib/openc3/utilities/open_telemetry.rb
@@ -1,0 +1,89 @@
+# encoding: ascii-8bit
+
+# Copyright 2022 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can modify and/or redistribute it
+# under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation; version 3 with
+# attribution addendums as found in the LICENSE.txt
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+module OpenC3
+  @otel_enabled = false
+
+  def self.otel_enabled
+    @otel_enabled
+  end
+
+  def self.inject_context(hash)
+    if @otel_enabled
+      OpenTelemetry.propagation.inject(hash)
+    end
+  end
+
+  def self.with_context(hash)
+    if @otel_enabled
+      extracted_context = OpenTelemetry.propagation.extract(hash)
+      OpenTelemetry::Context.with_current(extracted_context) do
+        yield
+      end
+    else
+      yield
+    end
+  end
+
+  def self.in_span(span_name, tracer_name = 'openc3-tracer')
+    if @otel_enabled
+      tracer = OpenTelemetry.tracer_provider.tracer(tracer_name)
+      tracer.in_span(span_name) do |span|
+        yield span
+      end
+    else
+      yield nil
+    end
+  end
+
+  def self.setup_open_telemetry(service_name, support_rails = false)
+    if ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
+      split_services = ENV['OPENC3_OTEL'].to_s.split(',')
+      @otel_enabled = true if split_services.include?(service_name) or split_services.include?('ALL')
+
+      if @otel_enabled
+        require 'redis'
+        require 'httpclient'
+        require 'openc3/utilities/s3'
+        Aws::S3 # Load the Library
+        require 'opentelemetry/sdk'
+        require 'opentelemetry/exporter/otlp'
+        require 'opentelemetry/instrumentation/redis'
+        require 'opentelemetry/instrumentation/http_client'
+        require 'opentelemetry/instrumentation/aws_sdk'
+        if support_rails
+          require 'opentelemetry/instrumentation/rack'
+          require 'opentelemetry/instrumentation/action_pack'
+        end
+        OpenTelemetry::SDK.configure do |c|
+          c.service_name = service_name
+          if support_rails
+            c.use('OpenTelemetry::Instrumentation::Rack')
+            c.use('OpenTelemetry::Instrumentation::ActionPack', { enable_recognize_route: true })
+          end
+          c.use 'OpenTelemetry::Instrumentation::Redis', {
+            # The obfuscation of arguments in the db.statement attribute is enabled by default.
+            # To include the full query, set db_statement to :include.
+            # To obfuscate, set db_statement to :obfuscate.
+            # To omit the attribute, set db_statement to :omit.
+            db_statement: :include,
+          }
+          c.use 'OpenTelemetry::Instrumentation::HttpClient'
+          c.use 'OpenTelemetry::Instrumentation::AwsSdk'
+        end
+      end
+    end
+  end
+end

--- a/openc3/openc3.gemspec
+++ b/openc3/openc3.gemspec
@@ -95,6 +95,13 @@ spec = Gem::Specification.new do |s|
   s.add_runtime_dependency 'rufus-scheduler', '~> 3.8'
   s.add_runtime_dependency 'cbor', '~> 0.5.9.6'
   s.add_runtime_dependency 'jsonpath', '~> 1.1'
+  s.add_runtime_dependency 'opentelemetry-sdk', '~> 1.2'
+  s.add_runtime_dependency 'opentelemetry-exporter-otlp', '~> 0.24'
+  s.add_runtime_dependency 'opentelemetry-instrumentation-rack', '~> 0.21'
+  s.add_runtime_dependency 'opentelemetry-instrumentation-redis', '~> 0.24'
+  s.add_runtime_dependency 'opentelemetry-instrumentation-action_pack', '~> 0.2'
+  s.add_runtime_dependency 'opentelemetry-instrumentation-http_client', '~> 0.20'
+  s.add_runtime_dependency 'opentelemetry-instrumentation-aws_sdk', '~> 0.3'
 
   # Development Dependencies
   s.add_development_dependency 'dead_end', '~> 4.0'


### PR DESCRIPTION
closes #171 

To test add to compose.yaml:

```
openc3-jaeger:
  image: "${OPENC3_REGISTRY}/jaegertracing/all-in-one:1.38"
  command: ["--memory.max-traces=1000000"]
  ports:
    - "127.0.0.1:16686:16686"
  restart: on-failure
  environment:
    - "COLLECTOR_OTLP_ENABLED=true"
  env_file:
    - ".env"
 ```

Add to .env:

```
OTEL_EXPORTER_OTLP_ENDPOINT=http://openc3-jaeger:4318
OPENC3_OTEL=CMD__TLM__API
```
