### PR TITLE
Auto-Generate Docs when changes detected

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,36 @@
+name: Auto Build Docs
+
+on:
+  push:
+    paths:
+      - 'docs.openc3.com/**'
+    branches:
+      - main
+
+jobs:
+  build-and-commit:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required to push commits
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      
+      - name: Install dependencies
+        run: yarn
+        working-directory: docs.openc3.com
+
+      - name: Build docs
+        run: yarn build
+        working-directory: docs.openc3.com
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Automated Doc Build Change


### PR DESCRIPTION
Tested on a test branch, and seems to have worked well: https://github.com/OpenC3/cosmos/actions/runs/15595344557/job/43924345011

This workflow is triggered when changes to `docs.openc3.com` are detected and ran on "push to main". This will auto-commit to main the changes made to `docs/` folder. So no more need to check in changes made to `docs/`