### PR TITLE
Fix flashing 404 page on slow connections

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/src/router.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/src/router.js
@@ -26,7 +26,7 @@ import { Login } from '@openc3/vue-common/tools/base'
 import { Api } from '@openc3/js-common/services'
 
 const ROOT_PATHS = ['/', '/tools', '/tools/'] // where to redirect from
-const NOT_FOUND_TIMEOUT = 150 // how long to wait to get the tool to redirect to (ms)
+const DEFAULT_TOOL_TIMEOUT_MS = 150 // how long to wait to get the tool to redirect to (ms)
 const DEFAULT_TOOL_URL = '/tools/cmdtlmserver' // where to redirect to if we can't figure it out in time
 
 const getFirstTool = async () => {
@@ -71,7 +71,7 @@ router.beforeEach(async (to) => {
   if (ROOT_PATHS.includes(to.fullPath)) {
     const firstTool = await Promise.race([
       getFirstTool(),
-      timeout(NOT_FOUND_TIMEOUT),
+      timeout(DEFAULT_TOOL_TIMEOUT_MS),
     ])
     return firstTool?.url || DEFAULT_TOOL_URL
   }


### PR DESCRIPTION
I couldn't figure out a better solution without making significant changes to our traefik config and how we serve apps (which is why we ended up here in the first place when I tried this months ago). Single-spa is weird.

This change adds a spinner while the app tries to find a matching tool for the route and waits longer than before (previously 150ms) to show the actual 404 page. The timeout is 2s which I think is a decent compromise. It's enough time that even fairly slow connections should eventually get the single-spa app mounted and thus not flash the 404 page, while not making the user wait forever to eventually be shown a 404 if they go to a route that doesn't exist.