### PR TITLE
Move the raw-dialog to the top of the app window if dropped above it

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/CmdPacketsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/CmdPacketsTab.vue
@@ -84,7 +84,7 @@
       :target-name="d.target_name"
       :packet-name="d.packet_name"
       :visible="true"
-      :z-index="d.zIndex"
+      :z-index="d.zIndex * 2"
       @close="closeRawDialog(d)"
       @focus="focus(d)"
     />
@@ -101,8 +101,14 @@ export default {
   },
   mixins: [Updater],
   props: {
-    tabId: Number,
-    curTab: Number,
+    tabId: {
+      type: Number,
+      required: true,
+    },
+    curTab: {
+      type: Number,
+      required: true,
+    },
   },
   data() {
     return {

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/RawDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/RawDialog.vue
@@ -103,15 +103,25 @@ import Updater from './Updater'
 export default {
   mixins: [Updater],
   props: {
-    type: String,
+    type: {
+      type: String,
+      required: true,
+    },
     visible: Boolean,
-    targetName: String,
-    packetName: String,
+    targetName: {
+      type: String,
+      required: true,
+    },
+    packetName: {
+      type: String,
+      required: true,
+    },
     zIndex: {
       type: Number,
       default: 1,
     },
   },
+  emits: ['close', 'display', 'focus'],
   data() {
     return {
       header: '',
@@ -195,6 +205,9 @@ export default {
       // stop moving when mouse button is released
       document.onmouseup = null
       document.onmousemove = null
+
+      // Prevent user from dropping it above the top of the app window
+      this.top = Math.max(-47, this.top)
     },
     buildRawData: function () {
       return `${this.header}\nReceived Time: ${this.receivedTime}\nCount: ${this.receivedCount}\n${this.rawData}`

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/TlmPacketsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/TlmPacketsTab.vue
@@ -84,7 +84,7 @@
       :target-name="d.target_name"
       :packet-name="d.packet_name"
       :visible="true"
-      :z-index="d.zIndex"
+      :z-index="d.zIndex * 2"
       @close="closeRawDialog(d)"
       @focus="focus(d)"
     />
@@ -101,8 +101,14 @@ export default {
   },
   mixins: [Updater],
   props: {
-    tabId: Number,
-    curTab: Number,
+    tabId: {
+      type: Number,
+      required: true,
+    },
+    curTab: {
+      type: Number,
+      required: true,
+    },
   },
   data() {
     return {


### PR DESCRIPTION
- On mouseup, set the dialog's `top` to not be above the app window (-47 lines it up with the top of the tabs - see screenshot. More negative is more higher)
- I also doubled the z-indexes because this is somehow going below the log messages table header for @jmthomas, but it isn't for me... Not sure if this will fix that or not since I can't repro
<img width="1238" height="260" alt="image" src="https://github.com/user-attachments/assets/c5916a3c-21bb-45e5-9e04-3f10193f33b5" />