### PR TITLE
Fix binary output in Data Extractor

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
@@ -957,9 +957,9 @@ export default {
             } else {
               let rawVal = packet[key]['raw']
               if (Array.isArray(rawVal)) {
-                let hexString = ''
+                let hexString = '0x'
                 rawVal.forEach((val) => {
-                  hexString += val.toString(16)
+                  hexString += val.toString(16).padStart(2, '0').toUpperCase()
                 })
                 row[columnIndex] = hexString
               } else {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/LogMessages.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/LogMessages.vue
@@ -235,13 +235,10 @@ export default {
                   // This is binary data, display in hex.
                   let result = '0x'
                   for (let i = 0; i < message.message.raw.length; i++) {
-                    let nibble = message.message.raw[i]
+                    result += message.message.raw[i]
                       .toString(16)
+                      .padStart(2, '0')
                       .toUpperCase()
-                    if (nibble.length < 2) {
-                      nibble = '0' + nibble
-                    }
-                    result += nibble
                   }
                   message.message = result
                 } else {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/cmdUtilities.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/cmdUtilities.js
@@ -93,11 +93,7 @@ export default {
           // This is binary data, display in hex.
           returnValue = '0x'
           for (let part of value.raw) {
-            let nibble = part.toString(16).toUpperCase()
-            if (nibble.length < 2) {
-              nibble = '0' + nibble
-            }
-            returnValue += nibble
+            returnValue += part.toString(16).padStart(2, '0').toUpperCase()
           }
         } else if (value.json_class === 'Float' && value.raw) {
           returnValue = value.raw


### PR DESCRIPTION
Pretty easy to see this bug in the DEMO. Send a few MEMLOAD commands with data like `0x5` & `0xDEADBEEF`. Then extract the entire HEALTH_STATUS packet and look at BLOCKTEST. This change formats the value as a hex string with proper padding of single digit bytes.