### PR TITLE
Python __name__ variable not correct #2356

### DIFF
--- a/openc3/python/openc3/utilities/running_script.py
+++ b/openc3/python/openc3/utilities/running_script.py
@@ -1023,6 +1023,10 @@ class RunningScript:
 
                 # Execute the script
                 self.pre_line_time = time.time()
+                # script_globals["__name__"] == "openc3.utilities.running_script"
+                # ...so instead we set it to "__main__"
+                self.script_globals["__name__"] = "__main__"
+                self.script_globals["__file__"] = instrument_filename
                 exec(instrumented_script, self.script_globals)
 
             self.handle_output_io()
@@ -1364,8 +1368,15 @@ def start(procedure_name, line_no = 1, end_line_no = None, bind_variables=False,
             RunningScript.instance.script_engine.run_text(instrumented_script, filename = procedure_name)
     else:
         if bind_variables:
+            RunningScript.instance.script_binding[0]["__name__"] = RunningScript.instance.script_binding[0].get(
+                "__name__",
+                RunningScript.instance.script_globals.get("__name__", "__main__"),
+            )
+            RunningScript.instance.script_binding[0]["__file__"] = procedure_name
             exec(instrumented_script, RunningScript.instance.script_binding[0], RunningScript.instance.script_binding[1])
         else:
+            RunningScript.instance.script_globals["__name__"] = RunningScript.instance.script_globals.get("__name__", "__main__")
+            RunningScript.instance.script_globals["__file__"] = procedure_name
             exec(instrumented_script, RunningScript.instance.script_globals)
 
     if complete:


### PR DESCRIPTION
Closes #2356

Adds `__name__` and `__file__` to the script globals/bindings dict passed into `exec()` based on reasonable values from the `RunningScript` class.

# Assumptions

- Scripts run from the runner will always have "name" set to `openc3.utilities.running_script`. Instead, we'd prefer its value is "main"
- Scripts run from `start()` should inherit "name" from the calling script. If it's not set, set it to "main". I think this makes sense to do. Since `exec()` is ultimately called, it should print the "name" for the active namespace. If this isn't set, it will show `openc3.utilities.running_script` like before. Defaulting to "main" is a reasonable alternative.

# Validation

```python
# test.py
import mark_test

print("current_filename: " + RunningScript.instance.current_filename())
print("__name__: " + __name__)
print("__file__: " + __file__)

start("BOB/mark_test.py")

mark_test.main()
foo = mark_test.MarkTest()
```

```python
# BOB/mark_test.py
print("current_filename: " + RunningScript.instance.current_filename())
print("__name__: " + __name__)
print("__file__: " + __file__)
```

```python
# mark_test module
def main():
    print("__name__: " + __name__)
    print("__file__: " + __file__)

if __name__ == "__main__":
    main()
```

> For posterity on how I tested this: I built `mark_test` as a whl and copied that to the root of the `openc3-cosmos-cmd-tlm-api` container so pip install could find it. In my test plugin, I added this line to requirements.txt: `mark_test @ file://localhost/mark_test-0.1.0-py3-none-any.whl`. Installing/upgrading the test plugin would install my module.

## Output

Output after running `test.py` (looks expected ✅):

```
2025-10-21T02:32:56.749376Z (2025_09_22_18_57_06_823_temp.py:9): __file__: /gems/python_packages/lib/python3.12/site-packages/mark_test/__init__.py
2025-10-21T02:32:56.749376Z (2025_09_22_18_57_06_823_temp.py:9): __name__: mark_test
2025-10-21T02:32:56.645636Z (mark_test.py:3): __file__: BOB/mark_test.py
2025-10-21T02:32:56.543691Z (mark_test.py:2): __name__: __main__
2025-10-21T02:32:56.440883Z (mark_test.py:1): current_filename: BOB/mark_test.py
2025-10-21T02:32:56.231688Z (2025_09_22_18_57_06_823_temp.py:5): __file__: test.py
2025-10-21T02:32:56.129683Z (2025_09_22_18_57_06_823_temp.py:4): __name__: __main__
2025-10-21T02:32:56.026230Z (2025_09_22_18_57_06_823_temp.py:3): current_filename: test.py
```

Also validated that debug prints the expected values.

# Open questions

I wasn't sure how to import `start()` within `mark_test` module if that's even possible. If so, please let me know! One thing I tried was passing the start func via closure into a func in the module. However, "name" would correctly(?) resolve to the caller's ("main") instead of the module name ("mark_test"). I think because the scope of the closure was ultimately in `test.py`:

```python
# mark_test module
def foo(func):
  func()

# test.py
from mark_test import foo

def _start():
  start(BOB/mark_test.py)  

foo(_start)
```