### PR TITLE
[Enhancement] Bucket Explorer Refresh Interval configurable

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/src/tools/BucketExplorer/BucketExplorer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/src/tools/BucketExplorer/BucketExplorer.vue
@@ -262,7 +262,7 @@ export default {
     OutputDialog,
   },
   data() {
-    const refreshInterval = parseInt(localStorage.getItem('bucketExplorerRefreshInterval')) || 60
+    const refreshInterval = Number.parseInt(localStorage.getItem('bucketExplorerRefreshInterval')) || 60
 
     return {
       title: 'Bucket Explorer',


### PR DESCRIPTION
closes #2377

Persists the refresh interval set in Bucket Explorer in localStorage so that user's preferences are stored on their browser.
<img width="1143" height="674" alt="Screenshot 2025-10-14 at 5 53 58 PM" src="https://github.com/user-attachments/assets/2e064225-bf01-4415-a6b7-0c9807cc8cd9" />
