### PR TITLE
Add imports to command validator in documentation

### DIFF
--- a/docs.openc3.com/docs/configuration/command.md
+++ b/docs.openc3.com/docs/configuration/command.md
@@ -655,6 +655,9 @@ VALIDATOR custom_validator.py
 
 Defined in custom_validator.py:
 
+from openc3.packets.command_validator import CommandValidator
+from openc3.api import *
+
 class CustomValidator(CommandValidator):
     # Both the pre_check and post_check are passed the command packet that was sent
     # You can inspect the command in your checks as follows:
@@ -684,6 +687,8 @@ VALIDATOR custom_validator.rb
 Defined in custom_validator.rb:
 
 require 'openc3/packets/command_validator'
+require 'openc3/api/api'
+
 class CustomValidator < OpenC3::CommandValidator
   # Both the pre_check and post_check are passed the command packet that was sent
   # You can inspect the command in your checks as follows:


### PR DESCRIPTION
Added 2 imports for the python validator example
```python
from openc3.packets.command_validator import CommandValidator
from openc3.api import *
```

Added 1 import for the ruby validator example
```ruby
require 'openc3/api/api'
```

<img width="1926" height="1262" alt="image" src="https://github.com/user-attachments/assets/f4fefeb8-10ab-4bb5-9ccf-b97307474bf9" />

<img width="1918" height="1386" alt="image" src="https://github.com/user-attachments/assets/f92252fc-7dd4-40e2-a081-eaa7e10f4e05" />
