### PR TITLE
use pnpm for publishing packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,28 +139,16 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: openc3/python/dist
-      - name: publish npm js package
+      - name: publish common npm packages
         if: ${{ github.event.inputs.update_latest == 'true' }}
-        run: npm publish --access public
-        working-directory: openc3-cosmos-init/plugins/packages/openc3-js-common
+        run: pnpm -F "@openc3/*-common" publish --access public
+        working-directory: openc3-cosmos-init/plugins
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: publish npm js package pre
+      - name: publish common npm packages pre
         if: ${{ github.event.inputs.update_latest != 'true' }}
-        run: npm publish --tag pre --access public
-        working-directory: openc3-cosmos-init/plugins/packages/openc3-js-common
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: publish npm vue package
-        if: ${{ github.event.inputs.update_latest == 'true' }}
-        run: npm publish --access public
-        working-directory: openc3-cosmos-init/plugins/packages/openc3-vue-common
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: publish npm vue package pre
-        if: ${{ github.event.inputs.update_latest != 'true' }}
-        run: npm publish --tag pre --access public
-        working-directory: openc3-cosmos-init/plugins/packages/openc3-vue-common
+        run: pnpm -F "@openc3/*-common" publish --tag pre --access public
+        working-directory: openc3-cosmos-init/plugins
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Update version to next

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/RELEASE.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/RELEASE.txt
@@ -1,3 +1,3 @@
-npm publish --access public
+pnpm publish --access public
 or
-npm publish --tag beta --access public
+pnpm publish --tag beta --access public

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/RELEASE.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/RELEASE.txt
@@ -1,3 +1,3 @@
-npm publish --access public
+pnpm publish --access public
 or
-npm publish --tag beta --access public
+pnpm publish --tag beta --access public


### PR DESCRIPTION
closes https://github.com/OpenC3/cosmos/issues/2446

Tested this locally with `pnpm pack` and inspecting package contents vs. using `npm pack`.