### PR TITLE
fix openc3_set_versions script

### DIFF
--- a/openc3/templates/tool_angular/package.json
+++ b/openc3/templates/tool_angular/package.json
@@ -1,2 +1,48 @@
+{
+  "name": "<%= tool_name %>",
   "version": "6.9.2-beta0",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test",
+    "build:single-spa:openc3-tool-template-angular": "ng build openc3-tool-<%= tool_name %> --configuration production",
+    "serve:single-spa:openc3-tool-template-angular": "ng s --project openc3-tool-<%= tool_name %> --disable-host-check --port 4200 --live-reload false"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^18.2.6",
+    "@angular/cdk": "^18.2.6",
+    "@angular/common": "^18.2.6",
+    "@angular/compiler": "^18.2.6",
+    "@angular/core": "^18.2.6",
+    "@angular/forms": "^18.2.6",
+    "@angular/material": "^18.2.10",
+    "@angular/platform-browser": "^18.2.6",
+    "@angular/platform-browser-dynamic": "^18.2.6",
+    "@angular/router": "^18.2.6",
+    "@astrouxds/astro-web-components": "^7.24.0",
     "@openc3/js-common": "6.9.1",
+    "rxjs": "~7.8.0",
+    "single-spa": "^5.9.5",
+    "single-spa-angular": "^9.2.0",
+    "tslib": "^2.7.0",
+    "zone.js": "^0.13.0"
+  },
+  "devDependencies": {
+    "@angular-builders/custom-webpack": "^18.0.0",
+    "@angular-devkit/build-angular": "^18.2.6",
+    "@angular/cli": "~18.2.6",
+    "@angular/compiler-cli": "^18.2.6",
+    "@types/jasmine": "~5.1.4",
+    "jasmine-core": "~5.4.0",
+    "karma": "~6.4.4",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "style-loader": "^4.0.0",
+    "typescript": "~5.5.4"
+  }
+}

--- a/openc3/templates/tool_react/package.json
+++ b/openc3/templates/tool_react/package.json
@@ -1,1 +1,51 @@
+{
+  "scripts": {
+    "start": "webpack serve",
+    "start:standalone": "webpack serve --env standalone",
+    "build": "concurrently pnpm:build:*",
+    "build:webpack": "webpack --mode=production",
+    "analyze": "webpack --mode=production --env analyze",
+    "lint": "eslint src --ext js",
+    "format": "prettier --write .",
+    "check-format": "prettier --check .",
+    "test": "cross-env BABEL_ENV=test jest",
+    "watch-tests": "cross-env BABEL_ENV=test jest --watch",
+    "coverage": "cross-env BABEL_ENV=test jest --coverage"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.13.3",
+    "@emotion/styled": "^11.11.0",
+    "@mui/material": "^6.1.1",
     "@openc3/js-common": "6.9.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "single-spa-react": "^5.1.4"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.2",
+    "@babel/eslint-parser": "^7.25.1",
+    "@babel/plugin-transform-runtime": "^7.25.4",
+    "@babel/preset-env": "^7.25.4",
+    "@babel/preset-react": "^7.23.3",
+    "@babel/runtime": "^7.25.6",
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^16.0.1",
+    "babel-jest": "^29.7.0",
+    "concurrently": "^9.0.1",
+    "cross-env": "^7.0.3",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-config-react-important-stuff": "^3.0.0",
+    "eslint-plugin-prettier": "^5.1.2",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-cli": "^29.7.0",
+    "prettier": "^3.1.1",
+    "pretty-quick": "^4.0.0",
+    "webpack": "^5.95.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-config-single-spa-react": "^4.0.5",
+    "webpack-dev-server": "^5.1.0",
+    "webpack-merge": "^6.0.1"
+  }
+}

--- a/openc3/templates/tool_svelte/package.json
+++ b/openc3/templates/tool_svelte/package.json
@@ -1,1 +1,48 @@
+{
+  "scripts": {
+    "build": "concurrently pnpm:build:*",
+    "build:rollup": "rollup -c --bundleConfigAsCjs",
+    "start": "rollup -c -w",
+    "serve": "sirv dist -c",
+    "test": "jest",
+    "format": "prettier --write --plugin-search-dir=. .",
+    "check-format": "prettier --plugin-search-dir=. --check .",
+    "prepare": "pnpm run smui-theme",
+    "smui-theme": "smui-theme compile build/smui.css -i src/theme"
+  },
+  "dependencies": {
+    "@astrouxds/astro-web-components": "^7.24.0",
     "@openc3/js-common": "6.9.1",
+    "@smui/button": "^7.0.0",
+    "@smui/common": "^7.0.0",
+    "@smui/card": "^7.0.0",
+    "@smui/list": "^7.0.0",
+    "@smui/menu": "^7.0.0",
+    "axios": "^1.7.7",
+    "single-spa-svelte": "^2.1.1",
+    "sirv-cli": "^2.0.2",
+    "svelte-portal": "^2.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.2",
+    "@babel/preset-env": "^7.25.4",
+    "@rollup/plugin-commonjs": "^28.0.0",
+    "@rollup/plugin-node-resolve": "^15.3.0",
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/svelte": "^5.2.1",
+    "babel-jest": "^29.7.0",
+    "concurrently": "^9.0.1",
+    "jest": "^29.7.0",
+    "postcss": "^8.4.47",
+    "prettier": "^3.1.1",
+    "prettier-plugin-svelte": "^3.2.7",
+    "rollup": "^4.22.4",
+    "rollup-plugin-livereload": "^2.0.5",
+    "rollup-plugin-postcss": "^4.0.2",
+    "rollup-plugin-svelte": "^7.1.6",
+    "rollup-plugin-terser": "^7.0.2",
+    "smui-theme": "^7.0.0",
+    "svelte": "^4.2.19",
+    "svelte-jester": "^5.0.0"
+  }
+}

--- a/openc3/templates/tool_vue/package.json
+++ b/openc3/templates/tool_vue/package.json
@@ -1,3 +1,36 @@
+{
+  "name": "<%= tool_name %>",
   "version": "6.9.2-beta0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "serve": "vite build --watch --mode dev-server",
+    "build": "vite build",
+    "lint": "eslint src",
+    "serve:standalone": "vite preview --mode standalone"
+  },
+  "dependencies": {
+    "@astrouxds/astro-web-components": "^7.24.0",
     "@openc3/js-common": "6.9.1",
     "@openc3/vue-common": "6.9.1",
+    "axios": "^1.7.7",
+    "date-fns": "^4.1.0",
+    "lodash": "^4.17.21",
+    "single-spa-vue": "^3.0.0",
+    "sprintf-js": "^1.1.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.1.5",
+    "@vue/eslint-config-prettier": "^9.0.0",
+    "@vue/test-utils": "^2.4.6",
+    "eslint": "^9.16.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.2.1",
+    "eslint-plugin-vue": "^9.30.0",
+    "prettier": "^3.3.3",
+    "sass": "^1.80.4",
+    "vite": "^5.4.11",
+    "vue": "^3.5.13",
+    "vue-eslint-parser": "^9.4.3"
+  }
+}

--- a/openc3/templates/widget/package.json
+++ b/openc3/templates/widget/package.json
@@ -1,2 +1,28 @@
+{
+  "name": "<%= widget_name %>",
   "version": "6.9.2-beta0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@astrouxds/astro-web-components": "^7.24.0",
     "@openc3/vue-common": "6.9.1",
+    "vuetify": "^3.7.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.1.5",
+    "@vue/eslint-config-prettier": "^9.0.0",
+    "eslint": "^9.16.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.2.1",
+    "eslint-plugin-vue": "^9.30.0",
+    "prettier": "^3.3.3",
+    "sass": "^1.80.4",
+    "vite": "^5.4.11",
+    "vue": "^3.5.13",
+    "vite-plugin-style-inject": "^0.0.1",
+    "vue-eslint-parser": "^9.4.3"
+  }
+}

--- a/scripts/release/openc3_set_versions.rb
+++ b/scripts/release/openc3_set_versions.rb
@@ -153,6 +153,8 @@ package_dot_json_files.each do |rel_path|
         else
           mod_data << "\n"
         end
+      else
+        mod_data << line
       end
     else
       mod_data << line


### PR DESCRIPTION
closes https://github.com/OpenC3/cosmos/issues/2445

- fix bug in script
- reset broken package.json files to d11ad519ba16161d21d50f56cdfc0e3d85fa42e3
- run script to update them to 6.9.1 *(this sets `"version"` and common package dependency versions)*
- run script again to update to 6.9.2-beta0 *(this sets `"version"` and **DOESN'T** set common package dependency versions since dependencies should stay at released versions per previous discussions)*