### PR TITLE
[Bug] Add overflow y scrolling on modified files list

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/ModifiedPluginDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/ModifiedPluginDialog.vue
@@ -24,7 +24,7 @@
         <span> Modified Plugin </span>
         <v-spacer />
       </v-toolbar>
-      <v-card-text class="pa-3">
+      <v-card-text class="pa-3 card-container">
         <div>
           Plugin {{ plugin }} was modified. Would you like to delete the
           existing modified files?
@@ -126,6 +126,11 @@ export default {
 </script>
 
 <style scoped>
+.card-container {
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
 .file-list-container {
   max-height: 50vh;
   overflow-y: auto;


### PR DESCRIPTION
<img width="1018" height="676" alt="Screenshot 2025-10-17 at 3 11 34 PM" src="https://github.com/user-attachments/assets/d77be08b-e485-4922-8225-b6536e916959" />

Made the list of modified items scrollable with an increased max-height to limit opportunities where scroll is necessary.

closes #2397