### PR TITLE
Consider support pyproject.toml #2292

### DIFF
--- a/openc3/lib/openc3/utilities/cli_generator.rb
+++ b/openc3/lib/openc3/utilities/cli_generator.rb
@@ -133,7 +133,17 @@ module OpenC3
         end
         gemspec_filename = Dir['*.gemspec'][0]
         gemspec = File.read(gemspec_filename)
-        gemspec.gsub!('plugin.txt', 'plugin.txt requirements.txt')
+        gemspec.gsub!(/s\.files = Dir\.glob.*\n/) do |match|
+          <<RUBY
+# Prefer pyproject.toml over requirements.txt
+  python_dep_file = if File.exist?('pyproject.toml')
+    'pyproject.toml'
+  else
+    'requirements.txt'
+  end
+  s.files = Dir.glob("{targets,lib,tools,microservices}/**/*") + %w(Rakefile README.md LICENSE.txt plugin.txt) + [python_dep_file]
+RUBY
+        end
         File.write(gemspec_filename, gemspec)
 
         target_txt_filename = "targets/#{target_name}/target.txt"


### PR DESCRIPTION
Allows `pyproject.toml` to be used for installing a Python package and its dependencies. Currently, only `requirements.txt` is supported. Note that this change does not modify the generator to produce a `pyproject.toml` instead of `requirements.txt`. Rather, it enables users to create their own `pyproject.toml` which the system will prefer during plugin installation. Defaulting to generating `pyproject.toml` should be considered in the future, though.

## Plugin Generator

When a target is generated with `openc3.sh cli generate target FOO --python`, the generated gemspec file will now include:

```
# Prefer pyproject.toml over requirements.txt
python_dep_file = if File.exist?('pyproject.toml')
  'pyproject.toml'
else
  'requirements.txt'
end
s.files = Dir.glob("{targets,lib,tools,microservices}/**/*") + %w(Rakefile README.md LICENSE.txt plugin.txt) + [python_dep_file]
```

Instead of just:

```
s.files = Dir.glob("{targets,lib,tools,microservices}/**/*") + %w(Rakefile README.md LICENSE.txt plugin.txt requirements.txt)
```

The means a `pyproject.toml` file, if it exists, will be preferred for installing requirements. Otherwise, default to the current behavior of using `requirements.txt`.

## Plugin install

If a `pyproject.toml` file exists, set the `pip_args` to use it. If it doesn't exist, default to the current behavior of using `requirements.txt`.

## Validation

1. Created a new plugin and target. Confirmed it had the new gemspec format. Deleted `requirements.txt` and made a `pyproject.toml` file.
2. Installed the plugin via the admin console
3. Confirmed there were no error logs and the expected dependencies were installed. Confirmed the logs mentioned "pyproject.toml" during pip install
4. Also tried with default `requirements.txt` and confirmed logs mentioned that in logs instead of `pyproject.toml`