### PR TITLE
2515 unify openc3sh and openc3bat between regular and  project

### DIFF
--- a/docs.openc3.com/docs/getting-started/upgrading.md
+++ b/docs.openc3.com/docs/getting-started/upgrading.md
@@ -125,6 +125,37 @@ Downgrades are not necessarily supported. When upgrading COSMOS we need to upgra
 In general, patch releases (x.y.Z) can be downgraded, minor releases (x.Y.z) _might_ be able to be downgraded and major releases (X.y.z) are NOT able to be downgraded.
 :::
 
+## Upgrading from COSMOS Core to COSMOS Enterprise
+
+Going from COSMOS Core (open source) to COSMOS Enterprise (OpenC3 customer) is a straight forward process that will preserve all your data collected by COSMOS Core.
+
+:::info Coming Soon
+This process is being simplified in an upcoming release and will be integrated into the `openc3.sh upgrade` command.
+:::
+
+If you currently are using the `cosmos-project` repo to run COSMOS then you should separately clone the `cosmos-enterprise-project` repo at the same release tag and simply copy over the various files.
+
+The process should loook something like this:
+
+1. Clone the `cosmos-enterprise-project` and checkout the equivalent tag. You'll need to ensure you have your Personally Access Token set to clone the repo. See the project [README](https://github.com/OpenC3/cosmos-enterprise-project) for help.
+
+   `git clone https://github.com/OpenC3/cosmos-enterprise-project.git`
+   `git checkout v6.9.2`
+
+2. From your current `cosmos-project` directory, stop the current COSMOS application
+
+   `openc3.sh stop`
+
+3. Copy the project files from the Enterprise project to your current project
+
+   `cp -r cosmos-enterprise-project/* .`
+
+4. Start the new Enterprise application
+
+   `openc3.sh run`
+
+5. Test and verify functionality and commit your changes.
+
 ## Migrating From COSMOS 5 to COSMOS 6
 
 :::info Developers Only

--- a/openc3.bat
+++ b/openc3.bat
@@ -168,7 +168,7 @@ GOTO :EOF
 GOTO :EOF
 
 :test
-  REM Building OpenC3
+  REM Building COSMOS
   CALL scripts\windows\openc3_setup || exit /b
   docker compose -f compose.yaml -f compose-build.yaml build
   set args=%*
@@ -201,24 +201,24 @@ GOTO :EOF
 :usage
   if "%OPENC3_DEVEL%" == "1" (
     if "%OPENC3_ENTERPRISE%" == "1" (
-      @echo OpenC3 - Command and Control System (Enterprise Development Installation) 1>&2
+      @echo OpenC3 COSMOS - Command and Control System (Enterprise Development Installation) 1>&2
     ) else (
-      @echo OpenC3 - Command and Control System (Development Installation) 1>&2
+      @echo OpenC3 COSMOS - Command and Control System (Development Installation) 1>&2
     )
   ) else (
     if "%OPENC3_ENTERPRISE%" == "1" (
-      @echo OpenC3 - Command and Control System (Enterprise Runtime-Only Installation) 1>&2
+      @echo OpenC3 COSMOS - Command and Control System (Enterprise Runtime-Only Installation) 1>&2
     ) else (
-      @echo OpenC3 - Command and Control System (Runtime-Only Installation) 1>&2
+      @echo OpenC3 COSMOS - Command and Control System (Runtime-Only Installation) 1>&2
     )
   )
   @echo Usage: %0 COMMAND [OPTIONS] 1>&2
   @echo. 1>&2
   @echo DESCRIPTION: 1>&2
-  @echo   OpenC3 is a command and control system for embedded systems. This script 1>&2
+  @echo   COSMOS is a command and control system for embedded systems. This script 1>&2
   if "%OPENC3_DEVEL%" == "1" (
     @echo   provides a convenient interface for building, running, testing, and managing 1>&2
-    @echo   OpenC3 in Docker containers. 1>&2
+    @echo   COSMOS in Docker containers. 1>&2
     @echo. 1>&2
     if "%OPENC3_ENTERPRISE%" == "1" (
       @echo   This is an ENTERPRISE DEVELOPMENT installation with source code and build capabilities. 1>&2
@@ -227,7 +227,7 @@ GOTO :EOF
     )
   ) else (
     @echo   provides a convenient interface for running, testing, and managing 1>&2
-    @echo   OpenC3 in Docker containers. 1>&2
+    @echo   COSMOS in Docker containers. 1>&2
     @echo. 1>&2
     if "%OPENC3_ENTERPRISE%" == "1" (
       @echo   This is an ENTERPRISE RUNTIME-ONLY installation using pre-built images. 1>&2
@@ -238,35 +238,35 @@ GOTO :EOF
   @echo. 1>&2
   @echo COMMON COMMANDS: 1>&2
   if "%OPENC3_DEVEL%" == "1" (
-    @echo   start                 Build and run OpenC3 (equivalent to: build + run) 1>&2
-    @echo                         This is the typical command to get OpenC3 running. 1>&2
+    @echo   start                 Build and run COSMOS (equivalent to: build + run) 1>&2
+    @echo                         This is the typical command to get COSMOS running. 1>&2
     @echo. 1>&2
   ) else (
-    @echo   run                   Start OpenC3 containers 1>&2
+    @echo   run                   Start COSMOS containers 1>&2
     @echo                         Access at: http://localhost:2900 1>&2
     @echo. 1>&2
   )
-  @echo   stop                  Stop all running OpenC3 containers gracefully 1>&2
+  @echo   stop                  Stop all running COSMOS containers gracefully 1>&2
   @echo                         Allows containers to shutdown cleanly. 1>&2
   @echo. 1>&2
-  @echo   cli [COMMAND]         Run OpenC3 CLI commands in a container 1>&2
+  @echo   cli [COMMAND]         Run COSMOS CLI commands in a container 1>&2
   @echo                         Use 'cli help' for available commands 1>&2
   @echo                         Examples: 1>&2
   @echo                           %0 cli generate plugin MyPlugin 1>&2
   @echo                           %0 cli validate myplugin.gem 1>&2
   @echo. 1>&2
-  @echo   cliroot [COMMAND]     Run OpenC3 CLI commands as root user 1>&2
+  @echo   cliroot [COMMAND]     Run COSMOS CLI commands as root user 1>&2
   @echo                         For operations requiring root privileges 1>&2
   @echo. 1>&2
   if "%OPENC3_DEVEL%" == "1" (
     @echo DEVELOPMENT COMMANDS: 1>&2
-    @echo   build                 Build all OpenC3 Docker containers from source 1>&2
+    @echo   build                 Build all COSMOS Docker containers from source 1>&2
     @echo                         Required before first run or after code changes. 1>&2
     @echo. 1>&2
-    @echo   run                   Start OpenC3 containers in detached mode 1>&2
+    @echo   run                   Start COSMOS containers in detached mode 1>&2
     @echo                         Access at: http://localhost:2900 1>&2
     @echo. 1>&2
-    @echo   dev                   Start OpenC3 containers in development mode 1>&2
+    @echo   dev                   Start COSMOS containers in development mode 1>&2
     @echo                         Uses compose-dev.yaml for development. 1>&2
     @echo. 1>&2
   )
@@ -277,20 +277,20 @@ GOTO :EOF
   @echo                         Use '%0 util' to see available utilities. 1>&2
   @echo. 1>&2
   if "%OPENC3_DEVEL%" == "0" (
-    @echo   upgrade               Upgrade OpenC3 to latest version 1>&2
+    @echo   upgrade               Upgrade COSMOS to latest version 1>&2
     @echo                         Downloads and installs latest release. 1>&2
     @echo. 1>&2
   )
   @echo CLEANUP: 1>&2
   @echo   cleanup [OPTIONS]     Remove Docker volumes and data 1>&2
-  @echo                         WARNING: This deletes all OpenC3 data! 1>&2
+  @echo                         WARNING: This deletes all COSMOS data! 1>&2
   @echo                         Options: 1>&2
   @echo                           local  - Also remove local plugin files 1>&2
   @echo                           force  - Skip confirmation prompt 1>&2
   @echo. 1>&2
   @echo GETTING STARTED: 1>&2
   @echo   1. First time setup:     %0 start 1>&2
-  @echo   2. Access OpenC3:        http://localhost:2900 1>&2
+  @echo   2. Access COSMOS:        http://localhost:2900 1>&2
   @echo   3. Stop when done:       %0 stop 1>&2
   @echo   4. Remove everything:    %0 cleanup 1>&2
   @echo. 1>&2

--- a/openc3.sh
+++ b/openc3.sh
@@ -64,13 +64,13 @@ set -e
 usage() {
   if [ "$OPENC3_DEVEL" -eq 1 ] && [ "$OPENC3_ENTERPRISE" -eq 1 ]; then
     cat >&2 << EOF
-OpenC3 - Command and Control System (Enterprise Development Installation)
+OpenC3 COSMOS - Command and Control System (Enterprise Development Installation)
 Usage: $1 COMMAND [OPTIONS]
 
 DESCRIPTION:
-  OpenC3 is a command and control system for embedded systems. This script
+  COSMOS is a command and control system for embedded systems. This script
   provides a convenient interface for building, running, testing, and managing
-  OpenC3 in Docker containers.
+  COSMOS in Docker containers.
 
   This is an ENTERPRISE DEVELOPMENT installation with source code and build capabilities.
 
@@ -78,13 +78,13 @@ COMMON COMMANDS:
 EOF
   elif [ "$OPENC3_DEVEL" -eq 1 ]; then
     cat >&2 << EOF
-OpenC3 - Command and Control System (Development Installation)
+OpenC3 COSMOS - Command and Control System (Development Installation)
 Usage: $1 COMMAND [OPTIONS]
 
 DESCRIPTION:
-  OpenC3 is a command and control system for embedded systems. This script
+  COSMOS is a command and control system for embedded systems. This script
   provides a convenient interface for building, running, testing, and managing
-  OpenC3 in Docker containers.
+  COSMOS in Docker containers.
 
   This is a DEVELOPMENT installation with source code and build capabilities.
 
@@ -92,13 +92,13 @@ COMMON COMMANDS:
 EOF
   elif [ "$OPENC3_ENTERPRISE" -eq 1 ]; then
     cat >&2 << EOF
-OpenC3 - Command and Control System (Enterprise Runtime-Only Installation)
+OpenC3 COSMOS - Command and Control System (Enterprise Runtime-Only Installation)
 Usage: $1 COMMAND [OPTIONS]
 
 DESCRIPTION:
-  OpenC3 is a command and control system for embedded systems. This script
+  COSMOS is a command and control system for embedded systems. This script
   provides a convenient interface for running, testing, and managing
-  OpenC3 in Docker containers.
+  COSMOS in Docker containers.
 
   This is an ENTERPRISE RUNTIME-ONLY installation using pre-built images.
 
@@ -106,13 +106,13 @@ COMMON COMMANDS:
 EOF
   else
     cat >&2 << EOF
-OpenC3 - Command and Control System (Runtime-Only Installation)
+OpenC3 COSMOS - Command and Control System (Runtime-Only Installation)
 Usage: $1 COMMAND [OPTIONS]
 
 DESCRIPTION:
-  OpenC3 is a command and control system for embedded systems. This script
+  COSMOS is a command and control system for embedded systems. This script
   provides a convenient interface for running, testing, and managing
-  OpenC3 in Docker containers.
+  COSMOS in Docker containers.
 
   This is a RUNTIME-ONLY installation using pre-built images.
 
@@ -121,39 +121,39 @@ EOF
   fi
   if [ "$OPENC3_DEVEL" -eq 1 ]; then
     cat >&2 << EOF
-  start                 Build and run OpenC3 (equivalent to: build + run)
-                        This is the typical command to get OpenC3 running.
+  start                 Build and run COSMOS (equivalent to: build + run)
+                        This is the typical command to get COSMOS running.
 
 EOF
   else
     cat >&2 << EOF
-  run                   Start OpenC3 containers
+  run                   Start COSMOS containers
                         Access at: http://localhost:2900
 
 EOF
   fi
   cat >&2 << EOF
-  stop                  Stop all running OpenC3 containers gracefully
+  stop                  Stop all running COSMOS containers gracefully
                         Allows containers to shutdown cleanly.
 
-  cli [COMMAND]         Run OpenC3 CLI commands in a container
+  cli [COMMAND]         Run COSMOS CLI commands in a container
                         Use 'cli help' for available commands
                         Use 'cli --help' for Docker wrapper info
                         Examples:
                           $1 cli generate plugin MyPlugin
                           $1 cli validate myplugin.gem
 
-  cliroot [COMMAND]     Run OpenC3 CLI commands as root user
+  cliroot [COMMAND]     Run COSMOS CLI commands as root user
                         Same as 'cli' but with root privileges
 
 EOF
   if [ "$OPENC3_DEVEL" -eq 1 ]; then
     cat >&2 << EOF
 DEVELOPMENT COMMANDS:
-  build                 Build all OpenC3 Docker containers from source
+  build                 Build all COSMOS Docker containers from source
                         Required before first run or after code changes.
 
-  run                   Start OpenC3 containers in detached mode
+  run                   Start COSMOS containers in detached mode
                         Access at: http://localhost:2900
 
 EOF
@@ -168,7 +168,7 @@ EOF
 EOF
   if [ "$OPENC3_DEVEL" -eq 0 ]; then
     cat >&2 << EOF
-  upgrade               Upgrade OpenC3 to latest version
+  upgrade               Upgrade COSMOS to latest version
                         Downloads and installs latest release.
 
 EOF
@@ -176,7 +176,7 @@ EOF
   cat >&2 << EOF
 CLEANUP:
   cleanup [OPTIONS]     Remove Docker volumes and data
-                        WARNING: This deletes all OpenC3 data!
+                        WARNING: This deletes all COSMOS data!
                         Options:
                           local  - Also remove local plugin files
                           force  - Skip confirmation prompt
@@ -195,7 +195,7 @@ EOF
   cat >&2 << EOF
 GETTING STARTED:
   1. First time setup:     $1 start
-  2. Access OpenC3:        http://localhost:2900
+  2. Access COSMOS:        http://localhost:2900
   3. Stop when done:       $1 stop
   4. Remove everything:    $1 cleanup
 
@@ -230,7 +230,7 @@ case $1 in
     if [ "$2" == "--wrapper-help" ] || [ "$2" == "--help" ] || [ "$2" == "-h" ]; then
       echo "Usage: $0 cli [COMMAND] [OPTIONS]"
       echo ""
-      echo "Run OpenC3 CLI commands inside a Docker container as the default user."
+      echo "Run COSMOS CLI commands inside a Docker container as the default user."
       echo ""
       echo "What this wrapper does:"
       echo "  - Starts a temporary Docker container (removed after use)"
@@ -240,7 +240,7 @@ case $1 in
       echo ""
       echo "Prerequisites:"
       echo "  - Containers must be built first: $0 build"
-      echo "  - .env file must exist in the OpenC3 directory"
+      echo "  - .env file must exist in the COSMOS directory"
       echo ""
       echo "Common commands:"
       echo "  $0 cli help                           Show CLI command help"
@@ -277,7 +277,7 @@ case $1 in
     if [ "$2" == "--wrapper-help" ] || [ "$2" == "--help" ] || [ "$2" == "-h" ]; then
       echo "Usage: $0 cliroot [COMMAND] [OPTIONS]"
       echo ""
-      echo "Run OpenC3 CLI commands inside a Docker container as root user."
+      echo "Run COSMOS CLI commands inside a Docker container as root user."
       echo ""
       echo "This is the same as 'cli' but runs as root instead of the default user."
       echo "Use this when you need elevated privileges inside the container."
@@ -291,7 +291,7 @@ case $1 in
       echo ""
       echo "Prerequisites:"
       echo "  - Containers must be built first: $0 build"
-      echo "  - .env file must exist in the OpenC3 directory"
+      echo "  - .env file must exist in the COSMOS directory"
       echo ""
       echo "Common commands:"
       echo "  $0 cliroot help                       Show CLI command help"
@@ -322,10 +322,10 @@ case $1 in
       if [ "$OPENC3_DEVEL" -eq 1 ]; then
         echo "Usage: $0 start"
         echo ""
-        echo "Build and run OpenC3 containers."
+        echo "Build and run COSMOS containers."
         echo ""
         echo "This command:"
-        echo "  1. Builds all OpenC3 containers (equivalent to 'openc3.sh build')"
+        echo "  1. Builds all COSMOS containers (equivalent to 'openc3.sh build')"
         echo "  2. Starts all containers (equivalent to 'openc3.sh run')"
         echo ""
         echo "Options:"
@@ -333,7 +333,7 @@ case $1 in
       else
         echo "Usage: $0 start"
         echo ""
-        echo "Start OpenC3 containers."
+        echo "Start COSMOS containers."
         echo ""
         echo "This is an alias for 'run' command in runtime-only installations."
         echo ""
@@ -354,10 +354,10 @@ case $1 in
       if [ "$OPENC3_DEVEL" -eq 1 ]; then
         echo "Usage: $0 start-ubi"
         echo ""
-        echo "Build and run OpenC3 UBI containers."
+        echo "Build and run COSMOS UBI containers."
         echo ""
         echo "This command:"
-        echo "  1. Builds all OpenC3 UBI containers (equivalent to 'openc3.sh build-ubi')"
+        echo "  1. Builds all COSMOS UBI containers (equivalent to 'openc3.sh build-ubi')"
         echo "  2. Starts all UBI containers (equivalent to 'openc3.sh run-ubi')"
         echo ""
         echo "Options:"
@@ -365,7 +365,7 @@ case $1 in
       else
         echo "Usage: $0 start-ubi"
         echo ""
-        echo "Run all OpenC3 UBI containers in detached mode."
+        echo "Run all COSMOS UBI containers in detached mode."
         echo ""
         echo "This is an alias for 'run-ubi' command."
         echo ""
@@ -385,7 +385,7 @@ case $1 in
     if [ "$2" == "--help" ] || [ "$2" == "-h" ]; then
       echo "Usage: $0 stop"
       echo ""
-      echo "Stop all OpenC3 containers gracefully."
+      echo "Stop all COSMOS containers gracefully."
       echo ""
       if [ "$OPENC3_ENTERPRISE" -eq 1 ]; then
         echo "This command:"
@@ -416,7 +416,7 @@ case $1 in
     if [ "$2" == "--help" ] || [ "$2" == "-h" ]; then
       echo "Usage: $0 cleanup [local] [force]"
       echo ""
-      echo "Remove all OpenC3 docker volumes and data."
+      echo "Remove all COSMOS docker volumes and data."
       echo ""
       echo "WARNING: This is a destructive operation that removes ALL COSMOS data!"
       echo ""
@@ -463,7 +463,7 @@ case $1 in
     if [ "$2" == "--help" ] || [ "$2" == "-h" ]; then
       echo "Usage: $0 build"
       echo ""
-      echo "Build all OpenC3 docker containers."
+      echo "Build all COSMOS docker containers."
       echo ""
       if [ "$OPENC3_ENTERPRISE" -eq 1 ]; then
         echo "This command:"
@@ -507,7 +507,7 @@ case $1 in
     if [ "$2" == "--help" ] || [ "$2" == "-h" ]; then
       echo "Usage: $0 build-ubi"
       echo ""
-      echo "Build all OpenC3 UBI (Universal Base Image) containers."
+      echo "Build all COSMOS UBI (Universal Base Image) containers."
       echo ""
       echo "This is used for enterprise deployments requiring Red Hat UBI base images,"
       echo "suitable for air-gapped and government environments."
@@ -551,7 +551,7 @@ case $1 in
     if [ "$2" == "--help" ] || [ "$2" == "-h" ]; then
       echo "Usage: $0 run"
       echo ""
-      echo "Run all OpenC3 containers in detached mode."
+      echo "Run all COSMOS containers in detached mode."
       echo ""
       echo "Containers will start in the background using docker compose up -d."
       echo ""
@@ -560,8 +560,8 @@ case $1 in
       echo "  docker compose logs -f              # Follow all logs"
       echo "  docker compose logs -f SERVICE      # Follow specific service logs"
       echo ""
-      echo "Access OpenC3:"
-      echo "  http://localhost:2900               # OpenC3 web interface"
+      echo "Access COSMOS:"
+      echo "  http://localhost:2900               # COSMOS web interface"
       echo ""
       echo "Common services:"
       echo "  openc3-operator                     Main orchestration service"
@@ -581,7 +581,7 @@ case $1 in
     if [ "$2" == "--help" ] || [ "$2" == "-h" ]; then
       echo "Usage: $0 run-ubi"
       echo ""
-      echo "Run all OpenC3 UBI (Universal Base Image) containers in detached mode."
+      echo "Run all COSMOS UBI (Universal Base Image) containers in detached mode."
       echo ""
       echo "This uses UBI-based container images and sets UBI-specific configurations:"
       echo "  - Image suffix: -ubi"
@@ -594,8 +594,8 @@ case $1 in
       echo "  docker compose logs -f              # Follow all logs"
       echo "  docker compose logs -f SERVICE      # Follow specific service logs"
       echo ""
-      echo "Access OpenC3:"
-      echo "  http://localhost:2900               # OpenC3 web interface"
+      echo "Access COSMOS:"
+      echo "  http://localhost:2900               # COSMOS web interface"
       echo ""
       echo "Common services:"
       echo "  openc3-operator                     Main orchestration service"
@@ -616,7 +616,7 @@ case $1 in
     if [ "$2" == "--help" ] || [ "$2" == "-h" ] || [ "$#" -eq 1 ]; then
       echo "Usage: $0 test COMMAND [OPTIONS]"
       echo ""
-      echo "Test OpenC3. This builds OpenC3 and runs the specified test suite."
+      echo "Test COSMOS. This builds COSMOS and runs the specified test suite."
       echo ""
       echo "Available commands:"
       echo "  rspec                       Run RSpec tests against Ruby code"
@@ -658,7 +658,7 @@ case $1 in
     if [ "$2" == "--help" ] || [ "$2" == "-h" ] || [ "$#" -eq 1 ]; then
       echo "Usage: $0 util COMMAND [OPTIONS]"
       echo ""
-      echo "Various OpenC3 utility commands."
+      echo "Various COSMOS utility commands."
       echo ""
       echo "Available commands:"
       echo "  encode STRING               Encode a string to base64"

--- a/scripts/linux/openc3_upgrade.sh
+++ b/scripts/linux/openc3_upgrade.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+set -e
+
+if ! command -v git &> /dev/null
+then
+  echo "git not found!!!"
+  exit 1
+fi
+
+# Determine if this is Core or Enterprise installation
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+if [ -d "$REPO_ROOT/openc3-enterprise-traefik" ]; then
+  IS_ENTERPRISE=true
+else
+  IS_ENTERPRISE=false
+fi
+
+usage() {
+  echo "Usage: openc3.sh upgrade <tag> --preview" >&2
+  echo "e.g. openc3.sh upgrade v6.4.1" >&2
+  echo "The '--preview' flag will show the diff without applying changes." >&2
+  if [ "$IS_ENTERPRISE" = false ]; then
+    echo "" >&2
+    echo "You can also upgrade to Enterprise versions of OpenC3 if you have access" >&2
+    echo "e.g. openc3.sh upgrade enterprise-v6.4.1" >&2
+    echo "NOTE: Upgrading to Enterprise preserves all your existing data" >&2
+    echo "but is a one-way operation and cannot be undone." >&2
+  fi
+  exit 1
+}
+
+if [ "$#" -eq 0 ]; then
+  usage $0
+fi
+
+# Check for help flag
+if [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
+  usage $0
+fi
+
+tag="$1"
+
+# Setup the 'cosmos' remote based on IS_ENTERPRISE or if upgrading to enterprise
+if [ "$IS_ENTERPRISE" = true ] || echo "$1" | grep -qi "enterprise"; then
+  COSMOS_URL="https://github.com/OpenC3/cosmos-enterprise-project.git"
+  if git remote -v | grep -q '^cosmos[[:space:]]'; then
+    echo "Setting 'cosmos' remote to the enterprise repository."
+    git remote set-url cosmos "$COSMOS_URL"
+  else
+    echo "Adding 'cosmos' remote for the enterprise repository."
+    git remote add cosmos "$COSMOS_URL"
+  fi
+
+  # Warn if upgrading from core to enterprise (but not if just previewing)
+  if [ "$IS_ENTERPRISE" = false ] && echo "$1" | grep -qi "enterprise" && [ "$2" != "--preview" ]; then
+    echo "" >&2
+    echo "WARNING: You are upgrading from OpenC3 Core to OpenC3 Enterprise." >&2
+    echo "This is a ONE-WAY operation and CANNOT be undone." >&2
+    echo "All your existing data will be preserved, but you will not be able" >&2
+    echo "to downgrade back to the Core version." >&2
+    echo "" >&2
+    read -p "Are you sure you want to continue? (yes/no): " -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
+      echo "Upgrade cancelled."
+      exit 1
+    fi
+  fi
+else
+  COSMOS_URL="https://github.com/OpenC3/cosmos-project.git"
+  if git remote -v | grep -q '^cosmos[[:space:]]'; then
+    echo "Setting 'cosmos' remote to the core repository."
+    git remote set-url cosmos "$COSMOS_URL"
+  else
+    echo "Adding 'cosmos' remote for the core repository."
+    git remote add cosmos "$COSMOS_URL"
+  fi
+fi
+
+# Strip a leading "enterprise-" from the tag argument if present
+case "$1" in
+  enterprise-*) tag="${1#enterprise-}" ;;
+  *) tag="$1" ;;
+esac
+
+# Fetch the latest changes from the 'cosmos' remote
+echo "Fetching latest changes from 'cosmos' remote."
+git fetch cosmos
+
+# Check the tag is valid
+if ! git tag | grep -q "^$tag$"; then
+  echo "Error: '$tag' is not a valid git tag." >&2
+  echo "Available tags:" >&2
+  git tag | sort
+  usage $0
+fi
+
+# Get the commit hash for the tag
+hash="$(git ls-remote cosmos refs/tags/v6.9.2 | awk '{print $1}')"
+
+# If the --preview flag is set, show the diff without applying changes
+if [ "$2" == "--preview" ]; then
+  git diff -R $hash
+  exit 0
+fi
+
+git diff -R $hash | git apply --whitespace=fix --exclude="plugins/*"
+echo "Applied changes from tag '$1'."
+echo "We recommend committing these changes to your local repository."
+echo "e.g. git commit -am 'Upgrade to $1'"
+echo "You can now run 'openc3.sh run' to start the upgraded OpenC3 environment."
+echo

--- a/scripts/windows/openc3_upgrade.bat
+++ b/scripts/windows/openc3_upgrade.bat
@@ -1,0 +1,124 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Check if git is available
+git --version >nul 2>&1
+if %errorlevel% neq 0 (
+    echo git not found!!!
+    exit /b 1
+)
+
+REM Determine if this is Core or Enterprise installation
+for /f "delims=" %%i in ('git rev-parse --show-toplevel') do set REPO_ROOT=%%i
+if exist "%REPO_ROOT%\openc3-enterprise-traefik" (
+    set IS_ENTERPRISE=true
+) else (
+    set IS_ENTERPRISE=false
+)
+
+REM Function to display usage
+:usage
+    echo Usage: openc3.bat upgrade ^<tag^> --preview
+    echo e.g. openc3.bat upgrade v6.4.1
+    echo The '--preview' flag will show the diff without applying changes.
+    if "%IS_ENTERPRISE%"=="false" (
+        echo.
+        echo You can also upgrade to Enterprise versions of OpenC3 if you have access
+        echo e.g. openc3.bat upgrade enterprise-v6.4.1
+        echo NOTE: Upgrading to Enterprise preserves all your existing data
+        echo but is a one-way operation and cannot be undone.
+    )
+    exit /b 1
+
+REM Check if arguments are provided
+if "%1"=="" goto usage
+
+REM Check for help flag
+if "%1"=="--help" goto usage
+if "%1"=="-h" goto usage
+
+set TAG=%1
+
+REM Setup the 'cosmos' remote based on IS_ENTERPRISE or if upgrading to enterprise
+echo %1 | findstr /i "enterprise" >nul 2>&1
+if "%IS_ENTERPRISE%"=="true" (
+    set UPGRADING_TO_ENTERPRISE=true
+) else if %errorlevel% equ 0 (
+    set UPGRADING_TO_ENTERPRISE=true
+) else (
+    set UPGRADING_TO_ENTERPRISE=false
+)
+
+if "%UPGRADING_TO_ENTERPRISE%"=="true" (
+    set COSMOS_URL=https://github.com/OpenC3/cosmos-enterprise-project.git
+    git remote -v | findstr /b "cosmos " >nul 2>&1
+    if %errorlevel% equ 0 (
+        echo Setting 'cosmos' remote to the enterprise repository.
+        git remote set-url cosmos !COSMOS_URL!
+    ) else (
+        echo Adding 'cosmos' remote for the enterprise repository.
+        git remote add cosmos !COSMOS_URL!
+    )
+
+    REM Warn if upgrading from core to enterprise (but not if just previewing)
+    if "%IS_ENTERPRISE%"=="false" if not "%2"=="--preview" (
+        echo.
+        echo WARNING: You are upgrading from OpenC3 Core to OpenC3 Enterprise.
+        echo This is a ONE-WAY operation and CANNOT be undone.
+        echo All your existing data will be preserved, but you will not be able
+        echo to downgrade back to the Core version.
+        echo.
+        set /p CONFIRM="Are you sure you want to continue? (yes/no): "
+        if /i not "!CONFIRM!"=="yes" (
+            echo Upgrade cancelled.
+            exit /b 1
+        )
+    )
+) else (
+    set COSMOS_URL=https://github.com/OpenC3/cosmos-project.git
+    git remote -v | findstr /b "cosmos " >nul 2>&1
+    if %errorlevel% equ 0 (
+        echo Setting 'cosmos' remote to the core repository.
+        git remote set-url cosmos !COSMOS_URL!
+    ) else (
+        echo Adding 'cosmos' remote for the core repository.
+        git remote add cosmos !COSMOS_URL!
+    )
+)
+
+REM Strip a leading "enterprise-" from the tag argument if present
+echo %1 | findstr /b /i "enterprise-" >nul 2>&1
+if %errorlevel% equ 0 (
+    set TAG=%1:enterprise-=%
+    set TAG=!TAG:enterprise-=!
+)
+
+REM Fetch the latest changes from the 'cosmos' remote
+echo Fetching latest changes from 'cosmos' remote.
+git fetch cosmos
+
+REM Check the tag is valid
+git tag | findstr /x "%TAG%" >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Error: '%TAG%' is not a valid git tag.
+    echo Available tags:
+    git tag | sort
+    goto usage
+)
+
+REM Get the commit hash for the tag
+for /f "tokens=1" %%a in ('git ls-remote cosmos refs/tags/%TAG%') do set HASH=%%a
+
+REM If the --preview flag is set, show the diff without applying changes
+if "%2"=="--preview" (
+    git diff -R %HASH%
+    exit /b 0
+)
+
+REM Apply the changes
+git diff -R %HASH% | git apply --whitespace=fix --exclude="plugins/*"
+echo Applied changes from tag '%1'.
+echo We recommend committing these changes to your local repository.
+echo e.g. git commit -am "Upgrade to %1"
+echo You can now run 'openc3.bat run' to start the upgraded OpenC3 environment.
+echo.


### PR DESCRIPTION
Updated `openc3.sh` and `openc3.bat` to be in sync with -project repo. 

## Running in cosmos-project

```zsh
❯ ./openc3.sh build             
Error: 'build' command is only available in development environments
This appears to be a runtime-only installation.
```

```zsh
❯ ./openc3.sh build-ubi 
Error: 'build-ubi' command is only available in development environments
This appears to be a runtime-only installation.
```

## Running in cosmos

```zsh
❯ ./openc3.sh upgrade
Error: 'upgrade' command is only available in runtime environments
This appears to be a development installation.
```