### PR TITLE
Update to vite 7

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/package.json
@@ -14,10 +14,10 @@
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "1.14.1",
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vite-plugin-style-inject": "0.0.1",
     "vue": "3.5.22"
   }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-admin/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-admin/package.json
@@ -18,11 +18,11 @@
     "single-spa-vue": "3.0.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/package.json
@@ -20,11 +20,11 @@
     "sprintf-js": "1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/package.json
@@ -21,11 +21,11 @@
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "1.14.1",
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/package.json
@@ -26,11 +26,11 @@
     "sprintf-js": "1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/package.json
@@ -19,11 +19,11 @@
     "sprintf-js": "1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/package.json
@@ -20,11 +20,11 @@
     "sprintf-js": "1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-handbooks/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-handbooks/package.json
@@ -20,11 +20,11 @@
     "sprintf-js": "1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-iframe/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-iframe/package.json
@@ -21,11 +21,11 @@
     "sprintf-js": "1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/package.json
@@ -20,11 +20,11 @@
     "sprintf-js": "1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/package.json
@@ -20,11 +20,11 @@
     "sprintf-js": "1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/package.json
@@ -22,11 +22,11 @@
     "sprintf-js": "1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/package.json
@@ -20,11 +20,11 @@
     "sprintf-js": "1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmgrapher/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmgrapher/package.json
@@ -22,11 +22,11 @@
     "sprintf-js": "1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/package.json
@@ -23,11 +23,11 @@
     "sprintf-js": "1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "@vue/test-utils": "2.4.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/package.json
@@ -56,6 +56,6 @@
   },
   "devDependencies": {
     "prettier": "3.6.2",
-    "vite": "6.4.1"
+    "vite": "7.2.1"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/package.json
@@ -21,11 +21,11 @@
   "devDependencies": {
     "@babel/plugin-transform-modules-systemjs": "7.28.5",
     "@types/systemjs": "6.15.3",
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "prettier": "3.6.2",
     "sass": "1.93.3",
     "serve": "14.2.5",
-    "vite": "6.4.1",
+    "vite": "7.2.1",
     "vue": "3.5.22"
   },
   "peerDependencies": {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/package.json
@@ -90,8 +90,8 @@
     "vuex": "4.1.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "5.2.3",
+    "@vitejs/plugin-vue": "6.0.1",
     "prettier": "3.6.2",
-    "vite": "6.4.1"
+    "vite": "7.2.1"
   }
 }

--- a/openc3-cosmos-init/plugins/pnpm-lock.yaml
+++ b/openc3-cosmos-init/plugins/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: 1.14.1
         version: 1.14.1
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -52,11 +52,11 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vite-plugin-style-inject:
         specifier: 0.0.1
-        version: 0.0.1(vite@6.4.1(sass@1.93.3))
+        version: 0.0.1(vite@7.2.1(sass@1.93.3))
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -83,8 +83,8 @@ importers:
         version: 3.0.1
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -95,8 +95,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -129,8 +129,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -141,8 +141,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -178,8 +178,8 @@ importers:
         specifier: 1.14.1
         version: 1.14.1
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -190,8 +190,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -242,8 +242,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -254,8 +254,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -285,8 +285,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -297,8 +297,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -331,8 +331,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -343,8 +343,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -377,8 +377,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -389,8 +389,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -426,8 +426,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -438,8 +438,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -472,8 +472,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -484,8 +484,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -518,8 +518,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -530,8 +530,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -570,8 +570,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -582,8 +582,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -616,8 +616,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -628,8 +628,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -668,8 +668,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -680,8 +680,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -723,8 +723,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       '@vue/test-utils':
         specifier: 2.4.6
         version: 2.4.6
@@ -735,8 +735,8 @@ importers:
         specifier: 1.93.3
         version: 1.93.3
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -784,8 +784,8 @@ importers:
         specifier: 3.6.2
         version: 3.6.2
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
 
   packages/openc3-tool-base:
     dependencies:
@@ -830,8 +830,8 @@ importers:
         specifier: 6.15.3
         version: 6.15.3
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -842,8 +842,8 @@ importers:
         specifier: 14.2.5
         version: 14.2.5
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
       vue:
         specifier: 3.5.22
         version: 3.5.22
@@ -912,14 +912,14 @@ importers:
         version: 4.1.0(vue@3.5.22)
     devDependencies:
       '@vitejs/plugin-vue':
-        specifier: 5.2.3
-        version: 5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)
+        specifier: 6.0.1
+        version: 6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)
       prettier:
         specifier: 3.6.2
         version: 3.6.2
       vite:
-        specifier: 6.4.1
-        version: 6.4.1(sass@1.93.3)
+        specifier: 7.2.1
+        version: 7.2.1(sass@1.93.3)
 
 packages:
 
@@ -1374,6 +1374,9 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@rolldown/pluginutils@1.0.0-beta.29':
+    resolution: {integrity: sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==}
+
   '@rollup/rollup-android-arm-eabi@4.45.1':
     resolution: {integrity: sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==}
     cpu: [arm]
@@ -1512,11 +1515,11 @@ packages:
   '@types/web-bluetooth@0.0.20':
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
 
-  '@vitejs/plugin-vue@5.2.3':
-    resolution: {integrity: sha512-IYSLEQj4LgZZuoVpdSUCw3dIynTWQgPlaRP6iAvMle4My0HdYwr5g5wQAfwOeHQBmYwEkqF70nRpSilr6PoUDg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  '@vitejs/plugin-vue@6.0.1':
+    resolution: {integrity: sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^5.0.0 || ^6.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue: ^3.2.25
 
   '@vue-flow/background@1.3.2':
@@ -2045,8 +2048,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fdir@6.4.6:
-    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -2599,8 +2603,8 @@ packages:
   systemjs@6.15.1:
     resolution: {integrity: sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA==}
 
-  tinyglobby@0.2.14:
-    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
   to-regex-range@5.0.1:
@@ -2642,19 +2646,19 @@ packages:
     peerDependencies:
       vite: ^2.0.0
 
-  vite@6.4.1:
-    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vite@7.2.1:
+    resolution: {integrity: sha512-qTl3VF7BvOupTR85Zc561sPEgxyUSNSvTQ9fit7DEMP7yPgvvIGm5Zfa1dOM+kOwWGNviK9uFM9ra77+OjK7lQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@types/node': ^20.19.0 || >=22.12.0
       jiti: '>=1.21.0'
-      less: '*'
+      less: ^4.0.0
       lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -3160,6 +3164,8 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@rolldown/pluginutils@1.0.0-beta.29': {}
+
   '@rollup/rollup-android-arm-eabi@4.45.1':
     optional: true
 
@@ -3237,9 +3243,10 @@ snapshots:
 
   '@types/web-bluetooth@0.0.20': {}
 
-  '@vitejs/plugin-vue@5.2.3(vite@6.4.1(sass@1.93.3))(vue@3.5.22)':
+  '@vitejs/plugin-vue@6.0.1(vite@7.2.1(sass@1.93.3))(vue@3.5.22)':
     dependencies:
-      vite: 6.4.1(sass@1.93.3)
+      '@rolldown/pluginutils': 1.0.0-beta.29
+      vite: 7.2.1(sass@1.93.3)
       vue: 3.5.22
 
   '@vue-flow/background@1.3.2(@vue-flow/core@1.47.0(vue@3.5.22))(vue@3.5.22)':
@@ -3822,7 +3829,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fdir@6.4.6(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
 
@@ -4324,9 +4331,9 @@ snapshots:
 
   systemjs@6.15.1: {}
 
-  tinyglobby@0.2.14:
+  tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.4.6(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
   to-regex-range@5.0.1:
@@ -4361,18 +4368,18 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-style-inject@0.0.1(vite@6.4.1(sass@1.93.3)):
+  vite-plugin-style-inject@0.0.1(vite@7.2.1(sass@1.93.3)):
     dependencies:
-      vite: 6.4.1(sass@1.93.3)
+      vite: 7.2.1(sass@1.93.3)
 
-  vite@6.4.1(sass@1.93.3):
+  vite@7.2.1(sass@1.93.3):
     dependencies:
       esbuild: 0.25.8
-      fdir: 6.4.6(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.45.1
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
     optionalDependencies:
       fsevents: 2.3.3
       sass: 1.93.3

--- a/openc3/templates/tool_vue/package.json
+++ b/openc3/templates/tool_vue/package.json
@@ -20,7 +20,7 @@
     "sprintf-js": "^1.1.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.1.5",
+    "@vitejs/plugin-vue": "^6.0.1",
     "@vue/eslint-config-prettier": "^9.0.0",
     "@vue/test-utils": "^2.4.6",
     "eslint": "^9.16.0",
@@ -29,7 +29,7 @@
     "eslint-plugin-vue": "^9.30.0",
     "prettier": "^3.3.3",
     "sass": "^1.80.4",
-    "vite": "^5.4.11",
+    "vite": "^7.2.1",
     "vue": "^3.5.13",
     "vue-eslint-parser": "^9.4.3"
   }

--- a/openc3/templates/widget/package.json
+++ b/openc3/templates/widget/package.json
@@ -12,7 +12,7 @@
     "vuetify": "^3.7.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.1.5",
+    "@vitejs/plugin-vue": "^6.0.1",
     "@vue/eslint-config-prettier": "^9.0.0",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^9.1.0",
@@ -20,7 +20,7 @@
     "eslint-plugin-vue": "^9.30.0",
     "prettier": "^3.3.3",
     "sass": "^1.80.4",
-    "vite": "^5.4.11",
+    "vite": "^7.2.1",
     "vue": "^3.5.13",
     "vite-plugin-style-inject": "^0.0.1",
     "vue-eslint-parser": "^9.4.3"


### PR DESCRIPTION
They said security patches **will** be backported to 6.4.x, so we can have this be part of COSMOS 7.0.0 since it's a potential (though unlikely) breaking change for people with custom tools. The Vue plugin was also updated to have the correct peer dep version.

Our `main` branch is already on the latest version of Vite 6.x