### PR TITLE
Better error messages on plugin gem file upload #2516

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/controllers/plugins_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/plugins_controller.rb
@@ -101,6 +101,9 @@ class PluginsController < ModelController
           result = OpenC3::PluginModel.install_phase1(gem_file_path, store_id: params[:store_id], scope: scope)
         end
         render json: result
+      rescue OpenC3::EmptyGemFileError => error
+        render json: { status: 'error', message: error.message }, status: 400
+        logger.error(error.formatted)
       rescue Exception => error
         render json: { status: 'error', message: error.message }, status: 500
         logger.error(error.formatted)

--- a/openc3/lib/openc3/models/plugin_model.rb
+++ b/openc3/lib/openc3/models/plugin_model.rb
@@ -41,6 +41,8 @@ require 'tempfile'
 require 'fileutils'
 
 module OpenC3
+  class EmptyGemFileError < StandardError; end
+
   # Represents a OpenC3 plugin that can consist of targets, interfaces, routers
   # microservices and tools. The PluginModel installs all these pieces as well
   # as destroys them all when the plugin is removed.
@@ -87,6 +89,10 @@ module OpenC3
       tf = nil
       begin
         if File.exist?(gem_file_path)
+          if File.zero?(gem_file_path)
+            raise EmptyGemFileError, "Gem file is empty: #{gem_file_path}"
+          end
+
           # Load gem to internal gem server
           OpenC3::GemModel.put(gem_file_path, gem_install: false, scope: scope) unless validate_only
         else
@@ -209,7 +215,7 @@ module OpenC3
         # Handle python dependencies (pyproject.toml or requirements.txt)
         pyproject_path = File.join(gem_path, 'pyproject.toml')
         requirements_path = File.join(gem_path, 'requirements.txt')
-        
+
         if File.exist?(pyproject_path) || File.exist?(requirements_path)
           begin
             pypi_url = get_setting('pypi_url', scope: scope)


### PR DESCRIPTION
Checks if the `gem_file_path` references an empty file, and if so, raises `EmptyGemFileError` which is returned as a `400` error to the client. `400` because this should be considered as a malformed request from the client.

Previous error:
<img width="1160" height="131" alt="image" src="https://github.com/user-attachments/assets/b743d5dd-205e-419c-ab50-1d2568375e0a" />

New error:
<img width="1253" height="54" alt="image" src="https://github.com/user-attachments/assets/dc77faa4-6827-4030-95ef-03c1447ed34a" />

## Testing

```
> OPENC3_DEVEL='../openc3' OPENC3_NO_EXT=1 bundle exec rspec ./spec/controllers/plugins_controller_spec.rb:168

...

PluginsController
  POST create
    returns bad request when gem file is empty

Finished in 0.01534 seconds (files took 1.04 seconds to load)
1 example, 0 failures

...

>  OPENC3_DEVEL='../openc3' OPENC3_NO_EXT=1 bundle exec rspec ./spec/controllers/plugins_controller_spec.rb:178

...

PluginsController
  POST create
    raises EmptyGemFileError when gem file is empty

Finished in 0.00802 seconds (files took 0.9696 seconds to load)
1 example, 0 failures

...
```