### PR TITLE
Add dependabot ignore for npm packages we update manually

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,11 @@ updates:
       - "/docs.openc3.com/*"
     schedule:
       interval: "weekly"
+    ignore: # because we do extra stuff with these. See index.html in tool-base or `base_pkgs` in package_audit.rb
+      - dependency-name: "import-map-overrides"
+      - dependency-name: "single-spa"
+      - dependency-name: "systemjs"
+      - dependency-name: "vue"
+      - dependency-name: "vue-router"
+      - dependency-name: "vuetify"
+      - dependency-name: "vuex"


### PR DESCRIPTION
We bundle these files manually as part of our pre-release process with package_audit, so dependabot should leave them alone.