### PR TITLE
Fix gem update to 3.7.2

### DIFF
--- a/openc3-ruby/Dockerfile
+++ b/openc3-ruby/Dockerfile
@@ -79,7 +79,7 @@ RUN apk update \
   # Ruby 3.2+ no longer bundles libyaml so explicitly include
   yaml-dev \
   zeromq-dev \
-  && gem update --system \
+  && gem update --system 3.7.2 \
   && gem install rake \
   && gem install google-protobuf \
   && gem install grpc \

--- a/openc3-ruby/Dockerfile-ubi
+++ b/openc3-ruby/Dockerfile-ubi
@@ -69,7 +69,7 @@ RUN cd / \
     && make install \
     && rm -rf /usr/src/${TINI_DIR}
 RUN cd / \
-    && gem update --system \
+    && gem update --system 3.7.2 \
     && gem install rake \
     && gem install google-protobuf \
     && gem install grpc \


### PR DESCRIPTION
Otherwise we upgrade to 4.0.0 which brings in bundler 4.0.0 but our runtime dependency is ~>2.3 (for now). Let's allow 4.0.0 to settle for a bit and upgrade to 4.0.0 in the COSMOS 7 branch.