### PR TITLE
Printing binary causes SR to not finish #2621

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -2010,9 +2010,14 @@ export default {
             this.processLine(data)
             break
           case 'output':
-            // data.line can consist of multiple lines split by newlines
-            // thus we split and only output if the content is not empty
-            for (const line of data.line.split('\n')) {
+            // data.line can consist of multiple lines split by newlines,
+            // thus we split and only output if the content is not empty.
+            // We also need to ensure it's properly serialized as a string.
+            let dataLine = data.line
+            if (dataLine === null || dataLine === undefined) { dataLine = '' }
+            else if (typeof dataLine === 'object') { dataLine = JSON.stringify(dataLine) }
+            else { dataLine = String(dataLine) }
+            for (const line of dataLine.split('\n')) {
               if (line) {
                 if (this.messagesNewestOnTop) {
                   this.messages.unshift({ message: line })


### PR DESCRIPTION
See #2621

## Old behavior
The script runner UI hangs like this:
<img width="2042" height="736" alt="image" src="https://github.com/user-attachments/assets/062a9918-59b5-4dbf-8716-cf2afd3749cf" />

## New behavior
The script runner UI successfully runs the script with a properly serialized message:
<img width="2042" height="872" alt="image" src="https://github.com/user-attachments/assets/76120e3e-b296-4673-93f2-68da31bcc2c7" />

## Validation
Also tested with known, working script which expectedly has no change in behavior:
<img width="2044" height="862" alt="image" src="https://github.com/user-attachments/assets/b69eb949-a8a0-44f2-9f37-773bc3084853" />