### PR TITLE
Indicator for SR overrides

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -203,6 +203,27 @@
 
             <v-spacer />
             <div v-if="startOrGoButton === 'Start'">
+              <v-tooltip v-if="overridesCount > 0" :open-delay="600" location="top">
+                <template #activator="{ props }">
+                  <v-btn
+                    v-bind="props"
+                    class="mr-4"
+                    icon
+                    variant="text"
+                    density="compact"
+                    data-test="tlm-override-button"
+                    aria-label="TLM Overrides"
+                    @click="showOverrides = !showOverrides"
+                  >
+                    <v-badge :content="overridesCount > 99 ? '99+' : overridesCount" floating color="primary">
+                      <v-icon icon="mdi-application-cog-outline" />
+                    </v-badge>
+                  </v-btn>
+                </template>
+                <span>
+                  TLM Overrides ({{ overridesCount }})
+                </span>
+              </v-tooltip>
               <v-tooltip :open-delay="600" location="top">
                 <template #activator="{ props }">
                   <v-btn
@@ -809,6 +830,7 @@ export default {
       mnemonicChecker: new MnemonicChecker(),
       showScripts: false,
       showOverrides: false,
+      overridesCount: 0,
       commandEditor: {
         show: false,
         targetName: null,
@@ -1174,6 +1196,11 @@ export default {
         }
       }
     },
+    showOverrides: function (newVal, oldVal) {
+      if (oldVal && !newVal) {
+        this.updateOverridesCount()
+      }
+    },
   },
   created: async function () {
     // Ensure Offline Access Is Setup For the Current User
@@ -1189,6 +1216,8 @@ export default {
       .catch((error) => {
         // Do nothing
       })
+
+    this.updateOverridesCount()
 
     // Make NEW_FILENAME available to the template
     this.NEW_FILENAME = NEW_FILENAME
@@ -1355,6 +1384,11 @@ export default {
     this.cable.disconnect()
   },
   methods: {
+    updateOverridesCount: function () {
+      this.api.get_overrides().then((result) => {
+        this.overridesCount = result.length
+      })
+    },
     toggleVimMode() {
       AceEditorUtils.toggleVimMode(this.editor)
     },
@@ -1795,6 +1829,8 @@ export default {
       this.envDisabled = false
       this.pauseOrRetryDisabled = true
       this.stopDisabled = true
+      // Overrides can be set from a script
+      this.updateOverridesCount()
     },
     environmentHandler: function (event) {
       this.scriptEnvironment.env = event


### PR DESCRIPTION
## Changes

TLM Override button shows up in script runner if any overrides are set.

## Demo

[TLM Override button demo](https://github.com/user-attachments/assets/244ffbd3-2d0c-42ba-bc74-6f92ddcd282b)

If lot's of tlm overrides:

<img width="324" height="116" alt="image" src="https://github.com/user-attachments/assets/90cb4d3f-4bb4-4e8d-af0b-c2ff6917f214" />