### PR TITLE
Document PATH as reserved environment variable name

### DIFF
--- a/docs.openc3.com/docs/configuration/telemetry-screens.md
+++ b/docs.openc3.com/docs/configuration/telemetry-screens.md
@@ -1491,7 +1491,8 @@ at which point we send the command with the telemetry value we received.
 
 Scripts can be launched from a BUTTON using the `runScript()` method. `runScript()` takes three parameters,
 the name of the script, whether to open the script in the foreground of Script Runner (default = true), and a hash of
-environment variables. For example: `runScript('INST/procedures/script.rb', false, {'VAR': 'VALUE'})`
+environment variables. For example: `runScript('INST/procedures/script.rb', false, {'VAR': 'VALUE'})`.
+Note: Do not use `PATH` as an environment variable key as it is reserved by the system.
 
 
 | Parameter | Description | Required |

--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -7597,12 +7597,12 @@ script_run("<Script Name>", disconnect=False, environment=None, suite_runner=Non
 </TabItem>
 </Tabs>
 
-| Parameter    | Description                                                             |
-| ------------ | ----------------------------------------------------------------------- |
-| Script Name  | Full path name of the script starting with the target                   |
-| disconnect   | Whether to run the script in Disconnect mode                            |
-| environment  | Hash / dict of key / value items to set as script environment variables |
-| suite_runner | Hash / dict of suite runner options                                     |
+| Parameter    | Description                                                                                                      |
+| ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| Script Name  | Full path name of the script starting with the target                                                            |
+| disconnect   | Whether to run the script in Disconnect mode                                                                     |
+| environment  | Hash / dict of key / value items to set as script environment variables. Note: Do not use `PATH` as it is reserved. |
+| suite_runner | Hash / dict of suite runner options                                                                              |
 
 <Tabs groupId="script-language">
 <TabItem value="ruby" label="Ruby Example">


### PR DESCRIPTION
## Summary
- Added documentation noting that `PATH` should not be used as an environment variable key in `runScript()` and `script_run()` as it is reserved by the system
- Updated `telemetry-screens.md` with a note about the reserved `PATH` variable
- Updated `scripting-api.md` with a note in the `environment` parameter description

Fixes #2090

🤖 Generated with [Claude Code](https://claude.com/claude-code)