### PR TITLE
Add Force Re-init process

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,9 @@ OPENC3_TAG=latest
 OPENC3_LOCAL_MODE=1
 # Comment this variable to disable installing the Demo (don't set it to 0)
 OPENC3_DEMO=1
+# Uncomment to force the init container to reinstall all plugins even if the same version exists.
+# Use this to recover from a previously failed or interrupted init. Remove after successful init.
+# OPENC3_FORCE_INSTALL=1
 # Docker repo settings on where to get COSMOS containers
 OPENC3_REGISTRY=docker.io
 OPENC3_NAMESPACE=openc3inc

--- a/openc3/bin/openc3cli
+++ b/openc3/bin/openc3cli
@@ -381,9 +381,10 @@ def load_plugin(plugin_file_path, scope:, plugin_hash_file: nil, force: false, v
           gem_name = full_name.split('-')[0..-2].join('-')
           if file_gem_name == gem_name
             found = true
-            # Upgrade if version changed else do nothing
-            if file_full_name != full_name
-              update_plugin(plugin_file_path, plugin_name, scope: scope, existing_plugin_name: plugin_name, force: force)
+            force_install = force || ENV['OPENC3_FORCE_INSTALL']
+            # Upgrade if version changed or force install is set
+            if file_full_name != full_name || force_install
+              update_plugin(plugin_file_path, plugin_name, scope: scope, existing_plugin_name: plugin_name, force: force_install)
             else
               puts "No version change detected for: #{plugin_name}"
             end


### PR DESCRIPTION
closes #2382

Updating the `openc3cli` to allow force re-install, even if the version is the same. This situation has been observed if the init job is cancelled early, or the bucket pvc is removed and Redis still has all the plugins saved.

Testing steps documented on the corresponding enterprise PR: https://github.com/OpenC3/cosmos-enterprise/pull/417