### PR TITLE
Fix Python script syntax check and CheckError display

### DIFF
--- a/openc3-cosmos-script-runner-api/app/models/script.rb
+++ b/openc3-cosmos-script-runner-api/app/models/script.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2024, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -386,10 +386,12 @@ class Script < OpenC3::TargetFile
         tf.close()
         results, status = Open3.capture2e("python -m py_compile #{tf.path}")
         lines = []
-        if results and results.length > 0
+        success = status.respond_to?(:success?) ? status.success? : status == 0
+        if !success || (results and results.length > 0)
           results.each_line do |line|
             lines << line
           end
+          lines << "Syntax Error" if lines.empty?
           return(
             { 'title' => 'Syntax Check Failed', 'description' => lines.as_json().to_json(allow_nan: true) }
           )

--- a/openc3/python/openc3/script/script_runner.py
+++ b/openc3/python/openc3/script/script_runner.py
@@ -1,4 +1,4 @@
-# Copyright 2024 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -40,7 +40,9 @@ def script_list(scope=OPENC3_SCOPE):
 
 def script_syntax_check(script, scope=OPENC3_SCOPE):
     endpoint = "/script-api/scripts/temp.py/syntax"
-    response = openc3.script.SCRIPT_RUNNER_API_SERVER.request("post", endpoint, json=False, data=script, scope=scope)
+    # Explicitly set the headers to plain/text so the request.body is set correctly
+    headers = {"Content-Type": "text/plain"}
+    response = openc3.script.SCRIPT_RUNNER_API_SERVER.request("post", endpoint, json=False, data=script, headers=headers, scope=scope)
     if not response or response.status_code != 200:
         _script_response_error(response, "Script syntax check request failed", scope=scope)
     else:
@@ -120,7 +122,9 @@ def script_unlock(filename, scope=OPENC3_SCOPE):
 
 def script_instrumented(script, scope=OPENC3_SCOPE):
     endpoint = "/script-api/scripts/temp.py/instrumented"
-    response = openc3.script.SCRIPT_RUNNER_API_SERVER.request("post", endpoint, json=False, data=script, scope=scope)
+    # Explicitly set the headers to plain/text so the request.body is set correctly
+    headers = {"Content-Type": "text/plain"}
+    response = openc3.script.SCRIPT_RUNNER_API_SERVER.request("post", endpoint, json=False, data=script, headers=headers, scope=scope)
     if not response or response.status_code != 200:
         _script_response_error(response, "Script instrumented request failed", scope=scope)
     else:

--- a/openc3/python/openc3/utilities/running_script.py
+++ b/openc3/python/openc3/utilities/running_script.py
@@ -1,4 +1,4 @@
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -116,7 +116,7 @@ from openc3.utilities.target_file import TargetFile
 from openc3.io.stdout import Stdout
 from openc3.io.stderr import Stderr
 from openc3.top_level import kill_thread
-from openc3.script.exceptions import StopScript, SkipScript
+from openc3.script.exceptions import StopScript, SkipScript, CheckError
 from openc3.tools.test_runner.test import SkipTestCase
 from openc3.script.suite import Group
 from openc3.utilities.script_instrumentor import ScriptInstrumentor
@@ -1120,6 +1120,8 @@ class RunningScript:
 
         if exc_type.__name__ == "DRbConnError":
             Logger.error("Error Connecting to Command and Telemetry Server")
+        elif exc_type == CheckError:
+            Logger.error(str(exc_value))
         else:
             formatted_lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
             # Print the last 4 lines to show the exception, the ^^^^ line,


### PR DESCRIPTION
- Fix Python syntax check to use exit status code in addition to output when determining if py_compile failed. Some environments don't produce output on syntax errors but do return non-zero exit status.

- Add Content-Type: text/plain header to Python script_syntax_check and script_instrumented API requests. Without this header, Rails was not reading the request body correctly, causing empty text to be passed.

- Show only the error message for CheckError exceptions instead of full stack trace, matching Ruby behavior.