### PR TITLE
[Enhancement] Packet viewer refresh

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/src/tools/PacketViewer/PacketViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/src/tools/PacketViewer/PacketViewer.vue
@@ -692,7 +692,7 @@ export default {
         this.loadingTlmData = true
         loadingFirstTlm = true
       }
-      this.updater = setInterval(() => {
+      const update = () => {
         if (!this.targetName || !this.packetName) {
           if (loadingFirstTlm) {
             loadingFirstTlm = false
@@ -798,7 +798,9 @@ export default {
           loadingFirstTlm = false
           this.loadingTlmData = false
         }
-      }, this.refreshInterval)
+      }
+      update() // Fetch immediately
+      this.updater = setInterval(update, this.refreshInterval)
     },
     resetConfig: function () {
       this.refreshInterval = 1000


### PR DESCRIPTION
If packet viewer has a refresh interval of say 10 seconds, the _first_ fetch will also take 10 seconds. This is to ensure on startup, fetch is immediate, and the refresh interval starts subsequently.