### PR TITLE
Fix mnemonic checker crashes and false positives

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/autocomplete/mnemonicChecker.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/autocomplete/mnemonicChecker.js
@@ -67,7 +67,9 @@ export default class MnemonicChecker {
         // Strip trailing comments to avoid matching keywords in comments
         // This handles both Ruby (# comment) and Python (# comment) style
         // Be careful not to strip # inside strings
-        const commentMatch = line.match(/^([^#'"]*(?:(?:"[^"]*"|'[^']*')[^#'"]*)*)(#.*)$/)
+        const commentMatch = line.match(
+          /^([^#'"]*(?:(?:"[^"]*"|'[^']*')[^#'"]*)*)(#.*)$/,
+        )
         const lineWithoutComment = commentMatch ? commentMatch[1].trim() : line
 
         const cmdMatch = this.cmdKeywordExpressions.reduce((found, regex) => {
@@ -112,10 +114,7 @@ export default class MnemonicChecker {
           const firstQuote = mnemonicMatch.match(/^['"]/)
           if (firstQuote) {
             const quoteChar = firstQuote[0]
-            const closingQuoteIndex = mnemonicMatch.indexOf(
-              quoteChar,
-              1,
-            )
+            const closingQuoteIndex = mnemonicMatch.indexOf(quoteChar, 1)
             if (closingQuoteIndex > 0) {
               mnemonicMatch = mnemonicMatch.substring(1, closingQuoteIndex)
             }


### PR DESCRIPTION
- Fix undefined error when regex matches space-based syntax (use Group 2 instead of last group which can be undefined)
- Strip trailing comments before checking for keywords to prevent matching keywords like 'wait' in comments
- Extract only content within quoted strings for space-based command syntax to avoid including Ruby/Python keyword arguments (queue:, queue=) as command parameters

closes #2787