### PR TITLE
Fix Telemetry Grapher performance with large historical data

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
@@ -315,7 +315,10 @@ import 'uplot/dist/uPlot.min.css'
 const DEFAULT_X_AXIS_ITEM = '__time'
 // Max milliseconds to spend processing buffered data per animation frame
 // before yielding back to the browser for rendering
-const MAX_PROCESSING_MS = 50
+// We're calling requestAnimationFrame which is typically 60Hz or every 16.667ms
+// A good rule of thumb is to stay within roughly half the frame budget, so 8–10ms.
+// This leaves the other ~7–8ms for the browser to do layout, paint, compositing, and GC.
+const MAX_PROCESSING_MS = 10
 
 export default {
   components: {
@@ -1836,9 +1839,7 @@ export default {
       ) {
         const pointsToRemove = this.data[0].length - this.pointsSaved
         for (let j = 0; j < this.data.length; j++) {
-          // slice() creates a new contiguous array which is faster than
-          // splice(0, N) which shifts every remaining element in-place
-          this.data[j] = this.data[j].slice(pointsToRemove)
+          this.data[j].splice(0, pointsToRemove)
         }
       }
 

--- a/openc3/templates/tool_angular/package.json
+++ b/openc3/templates/tool_angular/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@angular/animations": "^18.2.6",
     "@angular/cdk": "^18.2.6",
-    "@angular/common": "^21.1.2",
+    "@angular/common": "^18.2.6",
     "@angular/compiler": "^18.2.6",
     "@angular/core": "^18.2.6",
     "@angular/forms": "^18.2.6",


### PR DESCRIPTION
Resolve UI freezing when graphing data with large time deltas by addressing multiple O(N) bottlenecks in Graph.vue received method:

- Merge duplicate timestamps into existing slots instead of splicing new entries into every data array (eliminates O(N*M) per duplicate)
- Add equal-to-last fast path to avoid binary search for common case
- Buffer incoming data via requestAnimationFrame with 10ms time limit to yield to browser during historical data floods
- Throttle graph re-renders to 1/sec during burst data reception