### PR TITLE
Switch widget builds from UMD library mode to SystemJS format

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/vite-BigWidget.config.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/vite-BigWidget.config.js
@@ -9,14 +9,15 @@ export default defineConfig({
     outDir: 'tools/widgets/BigWidget',
     emptyOutDir: true,
     sourcemap: true,
-    lib: {
-      entry: './src/BigWidget.vue',
-      name: 'BigWidget',
-      fileName: (format, entryName) => `${entryName}.${format}.min.js`,
-      formats: ['umd'],
-    },
     rollupOptions: {
+      input: './src/BigWidget.vue',
+      output: {
+        format: 'systemjs',
+        entryFileNames: 'BigWidget.umd.min.js',
+        inlineDynamicImports: true,
+      },
       external: ['vue', 'vuetify'],
+      preserveEntrySignatures: 'strict',
     },
   },
   plugins: [vue(), VitePluginStyleInject()],

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/vite-DataviewerquaternionWidget.config.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/vite-DataviewerquaternionWidget.config.js
@@ -9,14 +9,15 @@ export default defineConfig({
     outDir: 'tools/widgets/DataviewerquaternionWidget',
     emptyOutDir: true,
     sourcemap: true,
-    lib: {
-      entry: './src/DataviewerquaternionWidget.vue',
-      name: 'DataviewerquaternionWidget',
-      fileName: (format, entryName) => `${entryName}.${format}.min.js`,
-      formats: ['umd'],
-    },
     rollupOptions: {
+      input: './src/DataviewerquaternionWidget.vue',
+      output: {
+        format: 'systemjs',
+        entryFileNames: 'DataviewerquaternionWidget.umd.min.js',
+        inlineDynamicImports: true,
+      },
       external: ['vue', 'vuetify'],
+      preserveEntrySignatures: 'strict',
     },
   },
   plugins: [vue(), VitePluginStyleInject()],

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/vite-DataviewertimeWidget.config.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/vite-DataviewertimeWidget.config.js
@@ -9,14 +9,15 @@ export default defineConfig({
     outDir: 'tools/widgets/DataviewertimeWidget',
     emptyOutDir: true,
     sourcemap: true,
-    lib: {
-      entry: './src/DataviewertimeWidget.vue',
-      name: 'DataviewertimeWidget',
-      fileName: (format, entryName) => `${entryName}.${format}.min.js`,
-      formats: ['umd'],
-    },
     rollupOptions: {
+      input: './src/DataviewertimeWidget.vue',
+      output: {
+        format: 'systemjs',
+        entryFileNames: 'DataviewertimeWidget.umd.min.js',
+        inlineDynamicImports: true,
+      },
       external: ['vue', 'vuetify'],
+      preserveEntrySignatures: 'strict',
     },
   },
   plugins: [vue(), VitePluginStyleInject()],

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/vite-HelloworldWidget.config.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/vite-HelloworldWidget.config.js
@@ -9,14 +9,15 @@ export default defineConfig({
     outDir: 'tools/widgets/HelloworldWidget',
     emptyOutDir: true,
     sourcemap: true,
-    lib: {
-      entry: './src/HelloworldWidget.vue',
-      name: 'HelloworldWidget',
-      fileName: (format, entryName) => `${entryName}.${format}.min.js`,
-      formats: ['umd'],
-    },
     rollupOptions: {
+      input: './src/HelloworldWidget.vue',
+      output: {
+        format: 'systemjs',
+        entryFileNames: 'HelloworldWidget.umd.min.js',
+        inlineDynamicImports: true,
+      },
       external: ['vue', 'vuetify'],
+      preserveEntrySignatures: 'strict',
     },
   },
   plugins: [vue(), VitePluginStyleInject()],

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/src/tools/DataViewer/DynamicComponent.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/src/tools/DataViewer/DynamicComponent.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2022 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -56,7 +56,8 @@ export default {
   },
   async mounted() {
     try {
-      this.widgetType = await System.import(this.url)
+      const mod = await System.import(this.url)
+      this.widgetType = mod.default || mod
     } catch (e) {
       throw new Error(`Unknown widget: ${this.name}`)
     }

--- a/openc3/templates/widget/vite.config.js
+++ b/openc3/templates/widget/vite.config.js
@@ -9,14 +9,15 @@ export default defineConfig({
     outDir: 'tools/widgets/<%= widget_name %>',
     emptyOutDir: true,
     sourcemap: true,
-    lib: {
-      entry: './src/<%= widget_name %>.vue',
-      name: '<%= widget_name %>',
-      fileName: (format, entryName) => `${entryName}.${format}.min.js`,
-      formats: ['umd'],
-    },
     rollupOptions: {
+      input: './src/<%= widget_name %>.vue',
+      output: {
+        format: 'systemjs',
+        entryFileNames: '<%= widget_name %>.umd.min.js',
+        inlineDynamicImports: true,
+      },
       external: ['vue', 'vuetify'],
+      preserveEntrySignatures: 'strict',
     },
   },
   plugins: [vue(), VitePluginStyleInject()],


### PR DESCRIPTION
Replaces Vite lib mode with direct rollup options using SystemJS output format for widget builds. Updates DynamicComponent to handle default exports when loading widgets via System.import.

 Here's the summary:

  Timeline of the break:
  - Pre-Nov 2024: Webpack built widgets in a SystemJS-compatible format, System.import() worked
  - Nov 2024: Vite migration - demo widget configs created with formats: ['umd'] (broken)
  - Dec 2024: Widget template created at openc3/templates/widget/vite.config.js also with UMD (broken from the start)
  - Today: Fixed to use format: 'systemjs'

  Why UMD doesn't work: The app uses System.import() (SystemJS) to load widgets at runtime. While SystemJS has an AMD extra that theoretically supports UMD, vite-plugin-style-inject prepends code before the UMD wrapper, and the module detection doesn't work reliably. The tool plugins all use
  format: 'systemjs' in their vite configs - the widget configs should have followed the same pattern.

  Backward compatibility: Since widgets were broken for all users since the vite migration, there are no working UMD widgets in the wild to be backward-compatible with. The mod.default || mod change in DynamicComponent.vue is defensive - it handles both formats gracefully in case a UMD widget does somehow load successfully.