### PR TITLE
Add stored packet documentation to packet-types, interfaces, and protocols

### DIFF
--- a/docs.openc3.com/docs/configuration/interfaces.md
+++ b/docs.openc3.com/docs/configuration/interfaces.md
@@ -682,6 +682,10 @@ Interfaces also have the following methods that exist and have default implement
 1. **write** - Send a packet to the interface. COSMOS implements this method to allow the Protocol system to operate on the packet and the data before it is sent.
 1. **write_raw** - Send a raw binary string of data to the target. COSMOS implements this method by basically calling write_interface with the raw data.
 
+:::info Stored Telemetry
+Custom interfaces that read non-realtime data (e.g. recorded files, back-orbit data, or store-and-forward playback) should set `packet.stored = true` on telemetry packets before returning them. Stored packets are fully processed through the COSMOS pipeline (identification, decommutation, logging) but do **not** update the Current Value Table (CVT). This prevents historical data from overwriting real-time values in displays like Packet Viewer and Telemetry Viewer. See the [File Interface](#file-interface) for a built-in example of this behavior. Also see [Stored Packets](../guides/packet-types#stored-packets) for more details.
+:::
+
 :::warning Naming Conventions
 When creating your own interfaces, in most cases they will be subclasses of one of the built-in interfaces described below. It is important to know that both the filename and class name of the interface files must match with correct capitalization or you will receive "class not found" errors when trying to load your new interface. For example, an interface file called labview_interface.rb must contain the class LabviewInterface. If the class was named, LabVIEWInterface, for example, COSMOS would not be able to find the class because of the unexpected capitalization.
 :::

--- a/docs.openc3.com/docs/configuration/protocols.md
+++ b/docs.openc3.com/docs/configuration/protocols.md
@@ -813,6 +813,10 @@ We recommend using authenticated encryption modes like GCM (Galois/Counter Mode)
 
 Creating a custom protocol is easy and should be the default solution for customizing COSMOS Interfaces (rather than creating a new Interface class). However, creating custom Interfaces is still useful for defaulting parameters to values that always are fixed for your target and for including the necessary Protocols. The COSMOS Interfaces take a lot of parameters that can be confusing to your end users. Thus you may want to create a custom Interface just to hard coded these values and cut the available parameters down to something like the hostname and port to connect to.
 
+:::info Stored Telemetry
+Custom protocols that handle non-realtime data (e.g. recorded files, back-orbit data, or store-and-forward playback) should set `packet.stored = true` in the `read_packet()` method. Stored packets are fully processed through the COSMOS pipeline (identification, decommutation, logging) but do **not** update the Current Value Table (CVT). This prevents historical data from overwriting real-time values in displays like Packet Viewer and Telemetry Viewer. See [Stored Packets](../guides/packet-types#stored-packets) for more details. The [Preidentified Protocol](#preidentified-protocol) is one example that encodes and decodes the stored flag in its packet header.
+:::
+
 All custom Protocols should derive from the Protocol class [openc3/interfaces/protocols/protocol.rb](https://github.com/OpenC3/cosmos/blob/main/openc3/lib/openc3/interfaces/protocols/protocol.rb) (Ruby) and [openc3/interfaces/protocols/protocol.py](https://github.com/OpenC3/cosmos/blob/main/openc3/python/openc3/interfaces/protocols/protocol.py) (Python). This class defines the 9 methods that are relevant to writing your own protocol. The base class implementation for each method is included below as well as a discussion as to how the methods should be overridden and used in your own Protocols.
 
 :::info Ruby Protocol APIs

--- a/docs.openc3.com/docs/guides/packet-types.md
+++ b/docs.openc3.com/docs/guides/packet-types.md
@@ -48,6 +48,27 @@ The [STRUCTURE](/docs/configuration/telemetry#structure) and [APPEND_STRUCTURE](
 
 Packets marked [VIRTUAL](/docs/configuration/telemetry#virtual) are also automatically marked HIDDEN and DISABLED.
 
+## Stored Packets
+
+Packets can be marked as "stored" which means they represent non-realtime data such as back-orbit data, recorded data playback, or data read from files. Stored packets are fully processed through the COSMOS pipeline (identification, decommutation, logging) but they **do not update the Current Value Table (CVT)**. This means stored telemetry will not affect real-time displays like Packet Viewer or Telemetry Viewer.
+
+The stored flag is primarily set in two ways:
+
+1. **By an Interface** - The [File Interface](../configuration/interfaces#file-interface) has a `Stored` parameter (default: true) that automatically marks all telemetry read from files as stored.
+2. **By a Protocol** - Custom protocols can set `packet.stored = true` in their `read_packet()` method. The [Preidentified Protocol](../configuration/protocols#preidentified-protocol) also encodes and decodes the stored flag in its packet header.
+
+When building a [Custom Interface](../configuration/interfaces#custom-interfaces), you can set the stored flag on packets returned by the `read` method. When building a [Custom Protocol](../configuration/protocols#custom-protocols), the `read_packet()` method is the appropriate place to set the stored flag. See those sections for more details.
+
+Common use cases for stored packets include:
+
+- Processing archived telemetry files through the [File Interface](../configuration/interfaces#file-interface)
+- Replaying recorded data without disrupting real-time displays
+- Ingesting back-orbit or store-and-forward data from a spacecraft
+
+:::note
+Stored packets are still logged and available in tools like Telemetry Grapher and Data Extractor. The only difference is they do not update the CVT, so they won't change values shown in Packet Viewer, Telemetry Viewer, or affect LATEST packet lookups.
+:::
+
 ## Hidden Packets
 
 [HIDDEN](/docs/configuration/command#hidden-1) packets are regular packets that are intentionally hidden from packet chooser widgets and from code completion. Hidden command packets can still be sent from scripts. Hidden telemetry packet data can still be used in TlmViewer screens.


### PR DESCRIPTION
Stored packets (non-realtime data like back-orbit or file playback) are processed through the full pipeline but do not update the CVT. This was undocumented, so added a new Stored Packets section to packet-types.md and info callouts in the Custom Interfaces and Custom Protocols sections.