### PR TITLE
Fix wait_check blocking on user input when sleep_time is 0

### DIFF
--- a/openc3/python/openc3/api/api_shared.py
+++ b/openc3/python/openc3/api/api_shared.py
@@ -526,7 +526,7 @@ def wait_check_packet(
 
 
 def openc3_script_sleep(sleep_time=None):
-    if sleep_time:
+    if sleep_time is not None:
         time.sleep(float(sleep_time))
     else:
         input("Press any key to continue...")

--- a/openc3/python/openc3/api/cmd_api.py
+++ b/openc3/python/openc3/api/cmd_api.py
@@ -481,7 +481,7 @@ def get_cmd_time(target_name=None, command_name=None, scope=OPENC3_SCOPE, manual
                     type="CONVERTED",
                     scope=scope,
                 )
-                if not cur_time:
+                if cur_time is None:
                     continue
 
                 if cur_time > time:

--- a/openc3/python/openc3/interfaces/http_client_interface.py
+++ b/openc3/python/openc3/interfaces/http_client_interface.py
@@ -55,10 +55,10 @@ class HttpClientInterface(Interface):
         else:
             self.url = f"{self.protocol}://{self.hostname}:{self.port}"
         self.read_timeout = ConfigParser.handle_none(read_timeout)
-        if self.read_timeout:
+        if self.read_timeout is not None:
             self.read_timeout = float(self.read_timeout)
         self.connect_timeout = ConfigParser.handle_none(connect_timeout)
-        if self.connect_timeout:
+        if self.connect_timeout is not None:
             self.connect_timeout = float(self.connect_timeout)
         self.include_request_in_response = ConfigParser.handle_true_false(include_request_in_response)
 

--- a/openc3/python/openc3/interfaces/protocols/cmd_response_protocol.py
+++ b/openc3/python/openc3/interfaces/protocols/cmd_response_protocol.py
@@ -37,7 +37,7 @@ class CmdResponseProtocol(Protocol):
     ):
         super().__init__(allow_empty_data)
         self.response_timeout = ConfigParser.handle_none(response_timeout)
-        if self.response_timeout:
+        if self.response_timeout is not None:
             self.response_timeout = float(response_timeout)
         self.response_polling_period = float(response_polling_period)
         self.raise_exceptions = ConfigParser.handle_true_false(raise_exceptions)

--- a/openc3/python/openc3/interfaces/protocols/template_protocol.py
+++ b/openc3/python/openc3/interfaces/protocols/template_protocol.py
@@ -103,7 +103,7 @@ class TemplateProtocol(TerminatedProtocol):
         except Empty:
             pass
 
-        if self.initial_read_delay:
+        if self.initial_read_delay is not None:
             self.connect_complete_time = time.time() + self.initial_read_delay
 
     def disconnect_reset(self):
@@ -117,7 +117,7 @@ class TemplateProtocol(TerminatedProtocol):
         # Drop all data until the initial_read_delay is complete.
         # This gets rid of unused welcome messages,
         # prompts, and other junk on initial connections
-        if self.initial_read_delay and self.initial_read_delay_needed and self.connect_complete_time:
+        if self.initial_read_delay is not None and self.initial_read_delay_needed and self.connect_complete_time:
             if time.time() < self.connect_complete_time:
                 return ("STOP", extra)
             self.initial_read_delay_needed = False
@@ -187,7 +187,7 @@ class TemplateProtocol(TerminatedProtocol):
     def write_packet(self, packet):
         # Make sure we are past the initial data dropping period
         if (
-            self.initial_read_delay
+            self.initial_read_delay is not None
             and self.initial_read_delay_needed
             and self.connect_complete_time
             and time.time() < self.connect_complete_time

--- a/openc3/python/openc3/models/cvt_model.py
+++ b/openc3/python/openc3/models/cvt_model.py
@@ -491,7 +491,7 @@ class CvtModel(Model):
 
         # If a start_time is passed we're doing a QuestDB lookup and directly return the results
         # TODO: This currently does NOT support the override values
-        if start_time:
+        if start_time is not None:
             return cls.tsdb_lookup(items, start_time=start_time, end_time=end_time)
 
         # First generate a lookup dict of all the items represented so we can query the CVT

--- a/openc3/python/openc3/script/api_shared.py
+++ b/openc3/python/openc3/script/api_shared.py
@@ -604,7 +604,7 @@ def load_utility(procedure_name):
 
 
 def openc3_script_sleep(sleep_time=None):
-    if sleep_time:
+    if sleep_time is not None:
         time.sleep(float(sleep_time))
     else:
         input("Press any key to continue...")

--- a/openc3/python/openc3/script/web_socket_api.py
+++ b/openc3/python/openc3/script/web_socket_api.py
@@ -87,7 +87,7 @@ class WebSocketApi:
                             raise RuntimeError("Unauthorized")
                         if msg_type == "reject_subscription":
                             raise RuntimeError("Subscription Rejected")
-                        if timeout:
+                        if timeout is not None:
                             end_time = time.time()
                             if (end_time - start_time) > timeout:
                                 raise TimeoutError("No Data Timeout")
@@ -618,6 +618,6 @@ class StreamingWebSocketApi(CmdTlmWebSocketApi):
                     break
                 else:
                     data += batch
-                if timeout and (time.time() - read_all_start_time) > timeout:
+                if timeout is not None and (time.time() - read_all_start_time) > timeout:
                     break
         return data

--- a/openc3/python/openc3/streams/tcpip_client_stream.py
+++ b/openc3/python/openc3/streams/tcpip_client_stream.py
@@ -1,4 +1,4 @@
-# Copyright 2023 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -68,7 +68,7 @@ class TcpipClientStream(TcpipSocketStream):
                 read_socket = write_socket
 
         self.connect_timeout = ConfigParser.handle_none(connect_timeout)
-        if self.connect_timeout:
+        if self.connect_timeout is not None:
             self.connect_timeout = float(connect_timeout)
 
         super().__init__(write_socket, read_socket, write_timeout, read_timeout)

--- a/openc3/python/openc3/streams/tcpip_socket_stream.py
+++ b/openc3/python/openc3/streams/tcpip_socket_stream.py
@@ -31,13 +31,13 @@ class TcpipSocketStream(Stream):
         self.write_socket = write_socket
         self.read_socket = read_socket
         self.write_timeout = ConfigParser.handle_none(write_timeout)
-        if self.write_timeout:
+        if self.write_timeout is not None:
             self.write_timeout = float(write_timeout)
         else:
             Logger.warn("Warning: To avoid interface lock, write_timeout can not be None. Setting to 10 seconds.")
             self.write_timeout = 10.0
         self.read_timeout = ConfigParser.handle_none(read_timeout)
-        if self.read_timeout:
+        if self.read_timeout is not None:
             self.read_timeout = float(read_timeout)
 
         # Mutex on write is needed to protect from commands coming in from more

--- a/openc3/python/test/script/test_api_shared.py
+++ b/openc3/python/test/script/test_api_shared.py
@@ -78,6 +78,37 @@ class TestApiSharedProxy(unittest.TestCase):
             wait_check("INST HEALTH_STATUS COLLECTS < 0", 1)
 
 
+class TestOpenc3ScriptSleep(unittest.TestCase):
+    @patch("openc3.script.api_shared.time.sleep")
+    def test_sleep_with_zero_calls_time_sleep(self, mock_sleep):
+        """Regression: sleep_time=0 should call time.sleep(0), not prompt for input"""
+        from openc3.script.api_shared import openc3_script_sleep
+
+        openc3_script_sleep(0)
+        mock_sleep.assert_called_once_with(0.0)
+
+    @patch("openc3.script.api_shared.time.sleep")
+    def test_sleep_with_positive_value_calls_time_sleep(self, mock_sleep):
+        from openc3.script.api_shared import openc3_script_sleep
+
+        openc3_script_sleep(0.25)
+        mock_sleep.assert_called_once_with(0.25)
+
+    @patch("builtins.input", return_value="")
+    def test_sleep_with_none_prompts_for_input(self, mock_input):
+        from openc3.script.api_shared import openc3_script_sleep
+
+        openc3_script_sleep(None)
+        mock_input.assert_called_once_with("Press any key to continue...")
+
+    @patch("builtins.input", return_value="")
+    def test_sleep_with_no_args_prompts_for_input(self, mock_input):
+        from openc3.script.api_shared import openc3_script_sleep
+
+        openc3_script_sleep()
+        mock_input.assert_called_once_with("Press any key to continue...")
+
+
 @patch("openc3.script.API_SERVER", Proxy)
 @patch("openc3.script.api_shared.openc3_script_sleep", my_openc3_script_sleep)
 class TestApiShared(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Fixes #2827: `wait_check` prompts "Press any key to continue..." when the server call takes longer than the polling rate
- Root cause: Python treats `0` as falsy, so `if sleep_time:` skipped `time.sleep(0)` and fell into the `input()` prompt branch (Ruby, where this was ported from, treats `0` as truthy)
- Changed all numeric truthiness checks (`if value:`) to explicit None checks (`if value is not None:`) across 10 source files covering timeouts, delays, and timestamps

## Test plan
- [x] Added 4 unit tests for `openc3_script_sleep` verifying correct behavior with `0`, positive values, `None`, and no arguments
- [x] All 61 existing `test_api_shared.py` tests pass
- [x] Ruff linting passes on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)