### PR TITLE
Wrap videos row in docs

### DIFF
--- a/docs.openc3.com/docs/getting-started/installation.md
+++ b/docs.openc3.com/docs/getting-started/installation.md
@@ -14,17 +14,17 @@ The following sections describe how to get OpenC3 COSMOS installed on various op
 
 ### Installation Videos
 
-<div style={{display: 'flex', justifyContent: 'center', gap: '20px'}}>
-  <div style={{textAlign: 'center'}}>
-    <iframe width="320" height="180" src="https://www.youtube.com/embed/Luiy30mUYHs" title="Getting Started with COSMOS on Windows 11" frameborder="0" allow="autoplay; encrypted-media; picture-in-picture; fullscreen"></iframe>
+<div style={{display: 'flex', justifyContent: 'center', gap: '20px', flexWrap: 'wrap'}}>
+  <div style={{textAlign: 'center', flex: '1 1 280px', minWidth: '280px', maxWidth: '400px'}}>
+    <iframe style={{width: '100%', aspectRatio: '16/9'}} src="https://www.youtube.com/embed/Luiy30mUYHs" title="Getting Started with COSMOS on Windows 11" frameborder="0" allow="autoplay; encrypted-media; picture-in-picture; fullscreen"></iframe>
     <p><strong>Windows 11</strong></p>
   </div>
-  <div style={{textAlign: 'center'}}>
-    <iframe width="320" height="180" src="https://www.youtube.com/embed/hmhOVIzg4-M" title="Getting Started with COSMOS on macOS" frameborder="0" allow="autoplay; encrypted-media; picture-in-picture; fullscreen"></iframe>
+  <div style={{textAlign: 'center', flex: '1 1 280px', minWidth: '280px', maxWidth: '400px'}}>
+    <iframe style={{width: '100%', aspectRatio: '16/9'}} src="https://www.youtube.com/embed/hmhOVIzg4-M" title="Getting Started with COSMOS on macOS" frameborder="0" allow="autoplay; encrypted-media; picture-in-picture; fullscreen"></iframe>
     <p><strong>macOS</strong></p>
   </div>
-  <div style={{textAlign: 'center'}}>
-    <iframe width="320" height="180" src="https://www.youtube.com/embed/aLqAMvFjqY8" title="Getting Started with COSMOS on Linux Ubuntu" frameborder="0" allow="autoplay; encrypted-media; picture-in-picture; fullscreen"></iframe>
+  <div style={{textAlign: 'center', flex: '1 1 280px', minWidth: '280px', maxWidth: '400px'}}>
+    <iframe style={{width: '100%', aspectRatio: '16/9'}} src="https://www.youtube.com/embed/aLqAMvFjqY8" title="Getting Started with COSMOS on Linux Ubuntu" frameborder="0" allow="autoplay; encrypted-media; picture-in-picture; fullscreen"></iframe>
     <p><strong>Linux Ubuntu</strong></p>
   </div>
 </div>


### PR DESCRIPTION
Issue is [here](https://docs.openc3.com/docs/getting-started/installation#installation-videos). They were just overflowing before:
<img width="1240" height="490" alt="image" src="https://github.com/user-attachments/assets/fba98d6e-fb03-4a81-8fb7-2faf5413843c" />

Now they wrap when the screen is too narrow:
<img width="1512" height="798" alt="image" src="https://github.com/user-attachments/assets/6aa257f2-91d8-4d9c-bb0a-553f77706c19" />
<img width="1063" height="859" alt="image" src="https://github.com/user-attachments/assets/32d1e395-74d7-4621-a494-bb2b1e6a22d6" />
