### PR TITLE
[Enhancement] Limits Monitor Filtering

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/src/tools/LimitsMonitor/LimitsControl.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/src/tools/LimitsMonitor/LimitsControl.vue
@@ -60,8 +60,7 @@
           style="max-width: 300px"
           data-test="state-filter"
         >
-          <!-- eslint-disable-next-line vue/no-unused-vars -->
-          <template #selection="{ item, index }">
+          <template #selection="{ index }">
             <span v-if="index === 0"> {{ stateFilter.length }} selected </span>
           </template>
           <template #item="{ props: itemProps, item: selectItem }">


### PR DESCRIPTION
closes #1843

Using CSS to show/hide to filter the Limit Items to prevent triggering additional API calls. 

<img width="1492" height="696" alt="Screenshot 2026-02-25 at 4 37 18 PM" src="https://github.com/user-attachments/assets/79bd1b37-fcf3-4d7d-be5b-bc4418017740" />
