### PR TITLE
[Enhancement] Highlight AppNav item on Refresh

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
@@ -354,7 +354,10 @@ export default {
     )
   },
   mounted() {
-    globalThis.addEventListener('single-spa:routing-event', this.updateActiveItem)
+    globalThis.addEventListener(
+      'single-spa:routing-event',
+      this.updateActiveItem,
+    )
   },
   beforeUnmount() {
     globalThis.removeEventListener(


### PR DESCRIPTION
closes #2100 

Highlighting NavBar item has been supported for some time, but this change ensures that the item is highlighted on Refresh as well.

<img width="1032" height="684" alt="Screenshot 2026-02-27 at 10 53 54 AM" src="https://github.com/user-attachments/assets/1358f88a-4a8c-4ad5-9f42-ec558f67698b" />
