### PR TITLE
Migrate plugin Python package management from pip3 to uv

### DIFF
--- a/openc3/Dockerfile
+++ b/openc3/Dockerfile
@@ -58,4 +58,5 @@ RUN mkdir /gems && chown openc3:openc3 /gems \
 
 ENV HOME=/openc3
 ENV XDG_CACHE_HOME=/tmp/.cache
+ENV UV_CACHE_DIR=/gems/uv/
 USER ${USER_ID}:${GROUP_ID}

--- a/openc3/bin/pipinstall
+++ b/openc3/bin/pipinstall
@@ -1,14 +1,13 @@
 #!/bin/sh
-python3 -m venv $PYTHONUSERBASE
-source $PYTHONUSERBASE/bin/activate
-echo "pip3 install $@"
-pip3 install "$@"
+uv venv "$PYTHONUSERBASE"
+echo "uv pip install $@"
+uv pip install --python "$PYTHONUSERBASE" "$@"
 if [ $? -eq 0 ]; then
     echo "Command succeeded"
 else
     echo "Command failed - retrying with --no-index"
-    pip3 install --no-index "$@"
-    if [ $? -eq 0 ]; then
-        echo "ERROR: pip3 install failed"
+    uv pip install --python "$PYTHONUSERBASE" --no-index "$@"
+    if [ $? -ne 0 ]; then
+        echo "ERROR: uv pip install failed"
     fi
 fi

--- a/openc3/bin/pipuninstall
+++ b/openc3/bin/pipuninstall
@@ -1,10 +1,8 @@
 #!/bin/sh
-python3 -m venv $PYTHONUSERBASE
-source $PYTHONUSERBASE/bin/activate
-echo "pip3 uninstall $@"
-pip3 uninstall "$@"
+echo "uv pip uninstall $@"
+uv pip uninstall --python "$PYTHONUSERBASE" "$@"
 if [ $? -eq 0 ]; then
     echo "Command succeeded"
 else
-    echo "ERROR: pip3 uninstall failed"
+    echo "ERROR: uv pip uninstall failed"
 fi


### PR DESCRIPTION
- Replaced the pip3 calls with uv pip
- Using uv to create the virtual environment at `${PYTHONUSERBASE}`

```bash
/gems $ tree /gems/uv
/gems/uv
├── CACHEDIR.TAG
├── interpreter-v4
│   └── 4c6c6b68efe0f91a
│       └── 9956a7adb4259607.msgpack
└── sdists-v9

3 directories, 2 files
```

`Known behavior change`: Plugin Python packages that are already present in the base openc3 venv (e.g. `numpy`) will no longer appear in Admin Console → Packages after plugin installation. `uv pip` is smarter than `pip3` about deduplication and skips installing packages that are already satisfied, so nothing gets written to `$PYTHONUSERBASE`. The packages are still fully accessible to plugin scripts via `OPENC3_PYTHON_BIN`. This will be properly addressed in the upcoming per-plugin venv refactor.