### PR TITLE
[Bug] Command Sender Disable Param Conversion checkbox stuck

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
@@ -309,7 +309,7 @@ export default {
               checkbox: true,
               checked: this.cmdRaw,
               command: () => {
-                this.cmdRaw = !this.cmdRaw.checked
+                this.cmdRaw = !this.cmdRaw
               },
             },
             {


### PR DESCRIPTION
`.checked` does not exist, so once the checkbox was enabled this would get stuck. Fixing that.