### PR TITLE
Prevent path traversal in tool config names

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/SaveConfigDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/SaveConfigDialog.vue
@@ -142,8 +142,8 @@ export default {
       if (!this.configName) {
         return 'Config must have a name'
       }
-      if (/[/\\]|\.\./.test(this.configName)) {
-        return 'Config name must not contain / \\ or ..'
+      if (!/^[A-Za-z0-9_\-. ]+$/.test(this.configName)) {
+        return 'Config name must only contain letters, numbers, hyphens, underscores, spaces, and periods'
       }
       return null
     },

--- a/openc3/lib/openc3/models/tool_config_model.rb
+++ b/openc3/lib/openc3/models/tool_config_model.rb
@@ -19,6 +19,11 @@ require 'openc3/utilities/local_mode'
 
 module OpenC3
   class ToolConfigModel
+    class InvalidNameError < StandardError; end
+
+    # Allowlist: letters, digits, hyphens, underscores, spaces, and periods
+    VALID_NAME_PATTERN = /\A[A-Za-z0-9_\-. ]+\z/
+
     def self.config_tool_names(scope: $openc3_scope)
       _, keys = Store.scan(0, match: "#{scope}__config__*", type: 'hash', count: 100)
       # Just return the tool name that is used in the other APIs
@@ -26,26 +31,26 @@ module OpenC3
     end
 
     def self.list_configs(tool, scope: $openc3_scope)
-      raise "Invalid tool name: #{tool}" if tool.match?(%r{[/\\]|\.\.})
+      raise InvalidNameError, "Invalid tool name: #{tool}" unless tool.match?(VALID_NAME_PATTERN)
       Store.hkeys("#{scope}__config__#{tool}")
     end
 
     def self.load_config(tool, name, scope: $openc3_scope)
-      raise "Invalid tool name: #{tool}" if tool.match?(%r{[/\\]|\.\.})
-      raise "Invalid config name: #{name}" if name.match?(%r{[/\\]|\.\.})
+      raise InvalidNameError, "Invalid tool name: #{tool}" unless tool.match?(VALID_NAME_PATTERN)
+      raise InvalidNameError, "Invalid config name: #{name}" unless name.match?(VALID_NAME_PATTERN)
       Store.hget("#{scope}__config__#{tool}", name)
     end
 
     def self.save_config(tool, name, data, local_mode: true, scope: $openc3_scope)
-      raise "Invalid tool name: #{tool}" if tool.match?(%r{[/\\]|\.\.})
-      raise "Invalid config name: #{name}" if name.match?(%r{[/\\]|\.\.})
+      raise InvalidNameError, "Invalid tool name: #{tool}" unless tool.match?(VALID_NAME_PATTERN)
+      raise InvalidNameError, "Invalid config name: #{name}" unless name.match?(VALID_NAME_PATTERN)
       Store.hset("#{scope}__config__#{tool}", name, data)
       LocalMode.save_tool_config(scope, tool, name, data) if local_mode
     end
 
     def self.delete_config(tool, name, local_mode: true, scope: $openc3_scope)
-      raise "Invalid tool name: #{tool}" if tool.match?(%r{[/\\]|\.\.})
-      raise "Invalid config name: #{name}" if name.match?(%r{[/\\]|\.\.})
+      raise InvalidNameError, "Invalid tool name: #{tool}" unless tool.match?(VALID_NAME_PATTERN)
+      raise InvalidNameError, "Invalid config name: #{name}" unless name.match?(VALID_NAME_PATTERN)
       Store.hdel("#{scope}__config__#{tool}", name)
       LocalMode.delete_tool_config(scope, tool, name) if local_mode
     end

--- a/openc3/python/openc3/models/tool_config_model.py
+++ b/openc3/python/openc3/models/tool_config_model.py
@@ -16,7 +16,9 @@ from openc3.environment import OPENC3_SCOPE
 from openc3.utilities.local_mode import LocalMode
 from openc3.utilities.store import Store
 
-PATH_TRAVERSAL_PATTERN = re.compile(r"[/\\]|\.\.")
+
+# Allowlist: letters, digits, hyphens, underscores, spaces, and periods
+VALID_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_\-. ]+$")
 
 
 class ToolConfigModel:
@@ -29,16 +31,16 @@ class ToolConfigModel:
 
     @classmethod
     def list_configs(cls, tool: str, scope: str = OPENC3_SCOPE):
-        if PATH_TRAVERSAL_PATTERN.search(tool):
+        if not VALID_NAME_PATTERN.match(tool):
             raise RuntimeError(f"Invalid tool name: {tool}")
         keys = Store.hkeys(f"{scope}__config__{tool}")
         return [key.decode() for key in keys]
 
     @classmethod
     def load_config(cls, tool: str, name: str, scope: str = OPENC3_SCOPE):
-        if PATH_TRAVERSAL_PATTERN.search(tool):
+        if not VALID_NAME_PATTERN.match(tool):
             raise RuntimeError(f"Invalid tool name: {tool}")
-        if PATH_TRAVERSAL_PATTERN.search(name):
+        if not VALID_NAME_PATTERN.match(name):
             raise RuntimeError(f"Invalid config name: {name}")
         return Store.hget(f"{scope}__config__{tool}", name).decode()
 
@@ -51,9 +53,9 @@ class ToolConfigModel:
         local_mode: bool = True,
         scope: str = OPENC3_SCOPE,
     ):
-        if PATH_TRAVERSAL_PATTERN.search(tool):
+        if not VALID_NAME_PATTERN.match(tool):
             raise RuntimeError(f"Invalid tool name: {tool}")
-        if PATH_TRAVERSAL_PATTERN.search(name):
+        if not VALID_NAME_PATTERN.match(name):
             raise RuntimeError(f"Invalid config name: {name}")
         Store.hset(f"{scope}__config__{tool}", name, data)
         if local_mode:
@@ -61,9 +63,9 @@ class ToolConfigModel:
 
     @classmethod
     def delete_config(cls, tool: str, name: str, local_mode: bool = True, scope: str = OPENC3_SCOPE):
-        if PATH_TRAVERSAL_PATTERN.search(tool):
+        if not VALID_NAME_PATTERN.match(tool):
             raise RuntimeError(f"Invalid tool name: {tool}")
-        if PATH_TRAVERSAL_PATTERN.search(name):
+        if not VALID_NAME_PATTERN.match(name):
             raise RuntimeError(f"Invalid config name: {name}")
         Store.hdel(f"{scope}__config__{tool}", name)
         if local_mode:

--- a/openc3/spec/models/tool_config_model_spec.rb
+++ b/openc3/spec/models/tool_config_model_spec.rb
@@ -44,21 +44,32 @@ module OpenC3
         expect(names[0]).to match(/.*\/DEFAULT\/tool_config\/toolie\/namely.json.*/)
       end
 
-      it "rejects path traversal in tool name" do
-        expect { ToolConfigModel.save_config('../evil', 'name', '{}', scope: 'DEFAULT') }.to raise_error(RuntimeError, /Invalid tool name/)
-        expect { ToolConfigModel.save_config('evil/sub', 'name', '{}', scope: 'DEFAULT') }.to raise_error(RuntimeError, /Invalid tool name/)
-        expect { ToolConfigModel.save_config('evil\\sub', 'name', '{}', scope: 'DEFAULT') }.to raise_error(RuntimeError, /Invalid tool name/)
-        expect { ToolConfigModel.delete_config('../evil', 'name', scope: 'DEFAULT') }.to raise_error(RuntimeError, /Invalid tool name/)
-        expect { ToolConfigModel.load_config('../evil', 'name', scope: 'DEFAULT') }.to raise_error(RuntimeError, /Invalid tool name/)
-        expect { ToolConfigModel.list_configs('../evil', scope: 'DEFAULT') }.to raise_error(RuntimeError, /Invalid tool name/)
+      it "allows valid tool and config names" do
+        ToolConfigModel.save_config('my-tool', 'My Config 1.0', '{}', local_mode: false, scope: 'DEFAULT')
+        config = ToolConfigModel.load_config('my-tool', 'My Config 1.0', scope: 'DEFAULT')
+        expect(config).to eq('{}')
       end
 
-      it "rejects path traversal in config name" do
-        expect { ToolConfigModel.save_config('tool', '../../etc/passwd', '{}', scope: 'DEFAULT') }.to raise_error(RuntimeError, /Invalid config name/)
-        expect { ToolConfigModel.save_config('tool', 'sub/dir', '{}', scope: 'DEFAULT') }.to raise_error(RuntimeError, /Invalid config name/)
-        expect { ToolConfigModel.save_config('tool', 'sub\\dir', '{}', scope: 'DEFAULT') }.to raise_error(RuntimeError, /Invalid config name/)
-        expect { ToolConfigModel.delete_config('tool', '../evil', scope: 'DEFAULT') }.to raise_error(RuntimeError, /Invalid config name/)
-        expect { ToolConfigModel.load_config('tool', '../evil', scope: 'DEFAULT') }.to raise_error(RuntimeError, /Invalid config name/)
+      it "rejects invalid characters in tool name" do
+        expect { ToolConfigModel.save_config('../evil', 'name', '{}', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid tool name/)
+        expect { ToolConfigModel.save_config('evil/sub', 'name', '{}', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid tool name/)
+        expect { ToolConfigModel.save_config('evil\\sub', 'name', '{}', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid tool name/)
+        expect { ToolConfigModel.save_config('', 'name', '{}', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid tool name/)
+        expect { ToolConfigModel.save_config('evil@name', 'name', '{}', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid tool name/)
+        expect { ToolConfigModel.save_config('evil#name', 'name', '{}', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid tool name/)
+        expect { ToolConfigModel.delete_config('../evil', 'name', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid tool name/)
+        expect { ToolConfigModel.load_config('../evil', 'name', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid tool name/)
+        expect { ToolConfigModel.list_configs('../evil', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid tool name/)
+      end
+
+      it "rejects invalid characters in config name" do
+        expect { ToolConfigModel.save_config('tool', '../../etc/passwd', '{}', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid config name/)
+        expect { ToolConfigModel.save_config('tool', 'sub/dir', '{}', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid config name/)
+        expect { ToolConfigModel.save_config('tool', 'sub\\dir', '{}', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid config name/)
+        expect { ToolConfigModel.save_config('tool', '', '{}', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid config name/)
+        expect { ToolConfigModel.save_config('tool', 'name@evil', '{}', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid config name/)
+        expect { ToolConfigModel.delete_config('tool', '../evil', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid config name/)
+        expect { ToolConfigModel.load_config('tool', '../evil', scope: 'DEFAULT') }.to raise_error(ToolConfigModel::InvalidNameError, /Invalid config name/)
       end
     end
   end


### PR DESCRIPTION
Reject tool and config names containing /, \, or .. in ToolConfigModel to prevent writing arbitrary files within the shared /plugins directory. Added client-side validation in SaveConfigDialog.vue and backend validation in both Ruby and Python models with corresponding specs.