### PR TITLE
Cancel previous CI jobs for current PR/branch when new commit(s) are pushed

### DIFF
--- a/.github/workflows/api_tests.yml
+++ b/.github/workflows/api_tests.yml
@@ -19,6 +19,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   RUBYOPT: --disable=frozen_string_literal
   RUBYGEMS_URL: https://rubygems.org

--- a/.github/workflows/build_ubi.yml
+++ b/.github/workflows/build_ubi.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   openc3-build-ubi:
     if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   openc3-clamav-scan:
     if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   OPENC3_API_PASSWORD: password
   OPENC3_API_PORT: 2900

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -22,6 +22,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -22,6 +22,10 @@ on:
     paths:
       - "openc3-cosmos-init/plugins/packages/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # All jobs need permission to read repo contents
 permissions:
   contents: read

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,6 +18,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-commit:
     if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   OPENC3_ARGON2_PROFILE: "unsafe_cheapest"
 

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -26,6 +26,10 @@ on:
       - "openc3/python/pyproject.toml"
       - "openc3/python/uv.lock"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   OPENC3_CLOUD: local
   OPENC3_REDIS_HOSTNAME: localhost

--- a/.github/workflows/ruby_unit_tests.yml
+++ b/.github/workflows/ruby_unit_tests.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   RUBYOPT: --disable=frozen_string_literal
   RUBYGEMS_URL: https://rubygems.org

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   spelling:
     name: Codespell

--- a/.github/workflows/tool.yml
+++ b/.github/workflows/tool.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   OPENC3_API_PASSWORD: password
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Workaround for https://github.com/aquasecurity/trivy-action/issues/389
 env:
   TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2

--- a/.github/workflows/tsdb_integration_tests.yml
+++ b/.github/workflows/tsdb_integration_tests.yml
@@ -32,6 +32,10 @@ on:
       - ".github/workflows/tsdb_integration_tests.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tsdb-integration-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added [concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency) setting to all CI workflow definitions except for those related to releasing and the Playwright Firefox tests (which currently are only manually triggered)