### PR TITLE
The command `uv pip install --no-warn-script-location` no supported by `uv`

### DIFF
--- a/openc3/lib/openc3/models/plugin_model.rb
+++ b/openc3/lib/openc3/models/plugin_model.rb
@@ -268,16 +268,16 @@ module OpenC3
             if File.exist?(pyproject_path)
               Logger.info "Installing python packages from pyproject.toml with pypi_url=#{pypi_url}"
               if ENV['PIP_ENABLE_TRUSTED_HOST'].nil?
-                pip_args = "--no-warn-script-location -i #{pypi_url} #{gem_path}"
+                pip_args = "-i #{pypi_url} #{gem_path}"
               else
-                pip_args = "--no-warn-script-location -i #{pypi_url} --trusted-host #{URI.parse(pypi_url).host} #{gem_path}"
+                pip_args = "-i #{pypi_url} --trusted-host #{URI.parse(pypi_url).host} #{gem_path}"
               end
             else
               Logger.info "Installing python packages from requirements.txt with pypi_url=#{pypi_url}"
               if ENV['PIP_ENABLE_TRUSTED_HOST'].nil?
-                pip_args = "--no-warn-script-location -i #{pypi_url} -r #{requirements_path}"
+                pip_args = "-i #{pypi_url} -r #{requirements_path}"
               else
-                pip_args = "--no-warn-script-location -i #{pypi_url} --trusted-host #{URI.parse(pypi_url).host} -r #{requirements_path}"
+                pip_args = "-i #{pypi_url} --trusted-host #{URI.parse(pypi_url).host} -r #{requirements_path}"
               end
             end
             puts `/openc3/bin/pipinstall #{pip_args}`

--- a/openc3/lib/openc3/models/python_package_model.rb
+++ b/openc3/lib/openc3/models/python_package_model.rb
@@ -88,9 +88,9 @@ module OpenC3
       end
       Logger.info "Installing python package: #{name_or_path}"
       if ENV['PIP_ENABLE_TRUSTED_HOST'].nil?
-        pip_args = ["--no-warn-script-location", "-i", pypi_url, package_file_path]
+        pip_args = ["-i", pypi_url, package_file_path]
       else
-        pip_args = ["--no-warn-script-location", "-i", pypi_url, "--trusted-host", URI.parse(pypi_url).host, package_file_path]
+        pip_args = ["-i", pypi_url, "--trusted-host", URI.parse(pypi_url).host, package_file_path]
       end
       result = OpenC3::ProcessManager.instance.spawn(["/openc3/bin/pipinstall"] + pip_args, "package_install", package_filename, Time.now + 3600.0, scope: scope)
       return result.name


### PR DESCRIPTION
The command `uv pip install --no-warn-script-location` is a pip specific option and is not supported by `uv`.
The flag is intended to suppress a warning in `pip` that occurs when executable scripts are installed to a directory not in your system's `PATH`.

`uv` is designed to work with virtual environments by default, which avoids the `PATH` issue by installing packages into an isolated environment that is active when the command is run.

```sh
Using CPython 3.12.12 interpreter at: /usr/bin/python
Creating virtual environment at: /gems/python_packages
Using Python 3.12.12 environment at: /gems/python_packages
Resolved 1 package in 173ms
Downloading numpy (16.2MiB)
 Downloaded numpy
Prepared 1 package in 542ms
Installed 1 package in 103ms
Bytecode compiled 407 files in 217ms
 + numpy==2.4.2
uv pip install -i https://pypi.org/simple -r /tmp/d20260304-65-5nzh5h/gem/requirements.txt
Command succeeded
```

```sh
Using CPython 3.12.12 interpreter at: /usr/bin/python
Creating virtual environment at: /gems/python_packages
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at `/gems/python_packages`. Use `--clear` to replace it
Using Python 3.12.12 environment at: /gems/python_packages
Audited 1 package in 0.38ms
uv pip install -i https://pypi.org/simple -r /tmp/d20260304-149-x3dr2v/gem/requirements.txt
Command succeeded
```