### PR TITLE
Fix issue for getting otp using keycloak auth

### DIFF
--- a/openc3/lib/openc3/utilities/authentication.rb
+++ b/openc3/lib/openc3/utilities/authentication.rb
@@ -48,7 +48,8 @@ module OpenC3
     end
 
     def get_otp(scope: 'DEFAULT')
-      if @token.nil? or @token.empty?
+      session_token = token()
+      if session_token.nil? or session_token.empty?
         raise OpenC3AuthenticationError, "Uninitialized authentication: unable to get OTP"
       end
       retry_faraday_request do

--- a/openc3/python/openc3/utilities/authentication.py
+++ b/openc3/python/openc3/utilities/authentication.py
@@ -50,12 +50,13 @@ class OpenC3Authentication:
         return self._token
 
     def get_otp(self, scope="DEFAULT"):
-        if not self._token:
+        session_token = self.token()
+        if not session_token:
             raise OpenC3AuthenticationError("Uninitialized authentication: unable to get OTP")
         response = Session().get(
             self._generate_auth_url("/auth/otp"),
             params={"scope": scope},
-            headers={"Authorization": self.token()},
+            headers={"Authorization": session_token},
         )
         return response.text
 


### PR DESCRIPTION
Quick fix to handle differences between core and enterprise (keycloak) auth classes (creating token in constructor vs. in token getter)

related to https://github.com/OpenC3/cosmos/pull/2911