### PR TITLE
Increase max message size

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/Procfile
+++ b/openc3-cosmos-cmd-tlm-api/Procfile
@@ -1,6 +1,6 @@
 web: bin/rails s -b 0.0.0.0 -p 2901
 # Go logging is log_level (https://docs.anycable.io/anycable-go/configuration?id=logging-settings)
-ws: anycable-go --host 0.0.0.0 --port 3901 --path /openc3-api/cable --log_level error --ws_max_pending_size=50000000
+ws: anycable-go --host 0.0.0.0 --port 3901 --path /openc3-api/cable --log_level error --max_message_size=1000000 --ws_max_pending_size=50000000
 # Ruby logging is log-level (https://docs.anycable.io/ruby/logging?id=logging)
 # but Rails overrides this so we set it in config/application.rb
 rpc: bundle exec anycable --broadcast_adapter http --http_broadcast_url http://127.0.0.1:8090/_broadcast


### PR DESCRIPTION
This is temporary fix for command history to allow for lots of commands.  The longer term fix will be to add an "ALL" option to subscribe to all commands.