### PR TITLE
Calendar docs and UI bug fix

### DIFF
--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -8915,7 +8915,19 @@ create_timeline_activity(name, kind, start, stop, data={})
 | kind      | Type of the activity. One of COMMAND, SCRIPT, or RESERVE.                     |
 | start     | Start time of the activity. Time / datetime instance.                         |
 | stop      | Stop time of the activity. Time / datetime instance.                          |
-| data      | Hash / dict of data for COMMAND or SCRIPT type. Default is empty hash / dict. |
+| data      | Hash / dict of data for COMMAND or SCRIPT type. Default is empty hash / dict. Valid keys are described [below](#create_timeline_activity-data-parameter). |
+| scope     | Scope of the activity. Default is the OPENC3_SCOPE, usually "DEFAULT". |
+
+#### create_timeline_activity data parameter
+| Key | Value |
+|-----|-------|
+| username | Username to display as the creator of the activity. Default is "operator". |
+| customTitle | Custom title to display for the activity. Default is empty string which results in no custom title being shown. |
+| notes | Notes to display for the activity. Default is empty string, which results in no notes being shown. |
+| command | Command to execute for COMMAND type activities. |
+| script | Script to execute for SCRIPT type activities. Should be given as the path to the script file to run, starting with the target name, e.g. "INST/procedures/collect.rb". |
+| environment | Array of environment variable key/value pairs to set for SCRIPT type activities, e.g. `[{key: "USER", value: "JASON"}]` |
+
 
 <Tabs groupId="script-language">
 <TabItem value="ruby" label="Ruby Example">

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/calendar/ActivityCreateDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/calendar/ActivityCreateDialog.vue
@@ -236,7 +236,10 @@
                   />
                 </div>
                 <div v-else-if="kind === 'SCRIPT'" class="ma-3">
-                  <script-chooser @file="fileHandler" />
+                  <script-chooser
+                    :model-value="activityData"
+                    @file="fileHandler"
+                  />
                   <environment-chooser v-model="activityEnvironment" />
                 </div>
                 <div v-else>

--- a/openc3/lib/openc3/script/calendar.rb
+++ b/openc3/lib/openc3/script/calendar.rb
@@ -52,6 +52,14 @@ module OpenC3
       return _cal_handle_response(response, 'Failed to delete timeline')
     end
 
+    # Creates an activity for the specified timeline.
+    #
+    # @param name [String] The name of the timeline.
+    # @param kind [String] The kind of activity. Must be one of "COMMAND", "SCRIPT", or "RESERVE".
+    # @param start [DateTime] The start time of the activity.
+    # @param stop [DateTime] The stop time of the activity.
+    # @param data [Hash, optional] Additional data to associate with the activity. Defaults to {}. Any activity can provide "username", "notes", and "customTitle". "command", "script", and "reserve" keys are reserves for the corresponding activity kind, with "environment" also available for script activities.
+    # @param scope [String, optional] The scope of the activity. Defaults to OPENC3_SCOPE.
     def create_timeline_activity(name, kind:, start:, stop:, data: {}, scope: $openc3_scope)
       kind = kind.to_s.downcase()
       kinds = %w(command script reserve)

--- a/openc3/python/openc3/script/cosmos_calendar.py
+++ b/openc3/python/openc3/script/cosmos_calendar.py
@@ -56,6 +56,17 @@ def delete_timeline(name, force=False, scope=OPENC3_SCOPE):
 
 
 def create_timeline_activity(name, kind, start, stop, data=None, scope=OPENC3_SCOPE):
+    """
+    Creates an activity for the specified timeline.
+
+    Args:
+        name (str): The name of the timeline.
+        kind (str): The kind of activity. Must be one of "COMMAND", "SCRIPT", or "RESERVE".
+        start (datetime): The start time of the activity.
+        stop (datetime): The stop time of the activity.
+        data (dict, optional): Additional data to associate with the activity. Defaults to None. Any activity can provide "username", "notes", and "customTitle". "command", "script", and "reserve" keys are reserves for the corresponding activity kind, with "environment" also available for script activities.
+        scope (str, optional): The scope of the activity. Defaults to OPENC3_SCOPE.
+    """
     if data is None:
         data = {}
     kind = kind.lower()

--- a/openc3/spec/install/api_docs_spec.rb
+++ b/openc3/spec/install/api_docs_spec.rb
@@ -93,7 +93,7 @@ module OpenC3
       File.open(File.join(SPEC_DIR,'../../docs.openc3.com/docs/guides/scripting-api.md')) do |file|
         apis = false
         file.each do |line|
-          if line.strip.include?('###')
+          if line.strip.include?('###') && !line.strip.include?('####') # Only look at ### headings, not #### headings
             if line.include?("Migration")
               apis = true
               next


### PR DESCRIPTION
* Add documentation for `data` and `scope` parameters into `create_timeline_activity` script function
* Fix Calendar tool UI when editing existing script activity (was not loading the existing script selection on step 2 of edit modal)

(`scope` has been added since this screenshot was taken)
<img width="1564" height="1488" alt="image" src="https://github.com/user-attachments/assets/af0a7b98-e99f-4a82-8db8-3090051ca6c5" />

