### PR TITLE
Fix issue templates not populating in dialog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-about: Create a report to help us improve
+description: Create a report to help us improve
 title: ""
 labels: ["triage"]
 assignees: ""

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-about: Suggest an idea for this project
+description: Suggest an idea for this project
 title: ""
 labels: ["enhancement", "triage"]
 assignees: ""

--- a/.github/ISSUE_TEMPLATE/help---usage---general-question.yml
+++ b/.github/ISSUE_TEMPLATE/help---usage---general-question.yml
@@ -1,5 +1,5 @@
 name: Help / Usage / General Question
-about: I need help using or understanding OpenC3 COSMOS
+description: I need help using or understanding OpenC3 COSMOS
 title: ""
 labels: ["question"]
 assignees: ""


### PR DESCRIPTION
Use "description" rather than "about" -- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax