### PR TITLE
Add CrawlChat integration to docs.openc3.com

### DIFF
--- a/docs.openc3.com/docusaurus.config.js
+++ b/docs.openc3.com/docusaurus.config.js
@@ -21,6 +21,22 @@ const config = {
     v4: true
   },
 
+  headTags: [
+    {
+      tagName: "script",
+      attributes: {},
+      innerHTML: `
+        if (window.location.hostname === 'docs.openc3.com') {
+          var s = document.createElement('script');
+          s.src = 'https://crawlchat.app/embed.js';
+          s.id = 'crawlchat-script';
+          s.dataset.id = '69c2c5539542f047e7848e0d';
+          document.head.appendChild(s);
+        }
+      `,
+    },
+  ],
+
   // Set the production url of your site here
   url: "https://docs.openc3.com",
   // Set the /<baseUrl>/ pathname under which your site is served


### PR DESCRIPTION
Only loads on docs.openc3.com hostname, not in the COSMOS app.

Two layers of protection:
  1. Build-time: The COSMOS embedded docs use docusaurus-plugin.config.js, which doesn't have the headTags at all — so the script tag never makes it into that build.                                               
  2. Runtime: Even if someone copied the config over, the window.location.hostname === 'docs.openc3.com' check would prevent the script from loading on any other hostname.  

<img width="723" height="718" alt="Screenshot 2026-03-24 at 11 52 54 AM" src="https://github.com/user-attachments/assets/4c971116-a519-446b-94c0-caf6352f46d2" />