### PR TITLE
Show unentitled App Store plugins with disabled install button

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/controllers/plugins_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/plugins_controller.rb
@@ -38,7 +38,7 @@ class PluginsController < ModelController
     api_key_setting = OpenC3::SettingModel.get(name: 'store_api_key', scope: 'DEFAULT')
     api_key = api_key_setting['data'] if api_key_setting
 
-    test_url = "http://#{uri.host}:#{uri.port}/api/v1.1/cosmos_plugins/#{store_plugin_id}"
+    test_url = "http://#{uri.host}:#{uri.port}/api/v1.2/cosmos_plugins/#{store_plugin_id}"
     begin
       uri_obj = URI(test_url)
       req = Net::HTTP::Get.new(uri_obj)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginCard.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginCard.vue
@@ -55,12 +55,20 @@
     </v-card-text>
     <v-spacer />
     <v-card-actions class="flex-wrap">
-      <v-btn
-        text="Install"
-        append-icon="mdi-puzzle-plus"
-        variant="elevated"
-        @click.stop="install"
-      />
+      <v-tooltip :open-delay="600" location="top">
+        <template #activator="{ props }">
+          <span v-bind="entitled ? null : props">
+            <v-btn
+              text="Install"
+              append-icon="mdi-puzzle-plus"
+              variant="elevated"
+              :disabled="!entitled"
+              @click.stop="install"
+            />
+          </span>
+        </template>
+        <span> {{ accessTooltip }} </span>
+      </v-tooltip>
     </v-card-actions>
   </v-card>
   <plugin-details-dialog

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginDetailsDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginDetailsDialog.vue
@@ -64,7 +64,7 @@
           density="compact"
           variant="outlined"
           hide-details
-          class="version-select"
+          class="mt-1 version-select"
         />
       </v-card-subtitle>
       <!--
@@ -191,13 +191,20 @@
           color="red"
           @click="uninstall"
         />
-        <v-btn
-          v-else
-          text="Install"
-          append-icon="mdi-puzzle-plus"
-          variant="elevated"
-          @click="install"
-        />
+        <v-tooltip v-else :open-delay="600" location="top">
+          <template #activator="{ props }">
+            <span v-bind="entitled ? null : props">
+              <v-btn
+                text="Install"
+                append-icon="mdi-puzzle-plus"
+                variant="elevated"
+                :disabled="!entitled"
+                @click="install"
+              />
+            </span>
+          </template>
+          <span> {{ accessTooltip }} </span>
+        </v-tooltip>
         <v-btn
           v-if="versionRepository"
           text="Repository"

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginProps.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginProps.js
@@ -39,6 +39,8 @@ export default {
     checksum: String,
     versions: Array,
     current_version_id: Number,
+    access: String,
+    entitled: Boolean,
   },
   data: function () {
     return {
@@ -71,6 +73,8 @@ export default {
         checksum: this.checksum,
         versions: this.versions,
         current_version_id: this.current_version_id,
+        access: this.access,
+        entitled: this.entitled,
       }
     },
     imageContentsWithMimeType: function () {
@@ -115,6 +119,19 @@ export default {
     },
     isPluginInstalled: function () {
       return !!this.name // Plugins only have a title, not a name, from the store
+    },
+    accessTooltip: function () {
+      if (this.entitled) {
+        return null
+      }
+      if (localStorage.getItem('pluginStore.isApiKeySet') !== 'true') {
+        return 'Please add your App Store API key using the settings cog icon.'
+      }
+      if (this.access === 'enterprise') {
+        return 'A COSMOS Enterprise license is required for this plugin.'
+      } else {
+        return 'Please contact sales@openc3.com for access to this plugin.'
+      }
     },
   },
   created: async function () {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginStoreSettingsDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginStoreSettingsDialog.vue
@@ -125,6 +125,7 @@ export default {
   watch: {
     apiKey: function (val) {
       this.checkEnterpriseKey()
+      localStorage.setItem('pluginStore.isApiKeySet', !!val)
     },
     isEnterprise: function (val) {
       this.checkEnterpriseKey()

--- a/openc3/lib/openc3/models/plugin_store_model.rb
+++ b/openc3/lib/openc3/models/plugin_store_model.rb
@@ -18,7 +18,7 @@ module OpenC3
   class PluginStoreModel < Model
     PRIMARY_KEY = 'openc3_plugin_store'
     DEFAULT_STORE_URL = 'https://store.openc3.com'
-    JSON_ENDPOINT = '/api/v1.1/cosmos_plugins'
+    JSON_ENDPOINT = '/api/v1.2/cosmos_plugins'
 
     def self.set(plugin_store_data)
       Store.set(PRIMARY_KEY, plugin_store_data)


### PR DESCRIPTION
Closes https://github.com/OpenC3/app-store/issues/158

This disables the install button with a tooltip explaining access for unentitled plugins:
<img width="847" height="377" alt="image" src="https://github.com/user-attachments/assets/70762615-3d71-4b64-86bc-b6546404fdc8" />

The App Store side ([PR](https://github.com/OpenC3/app-store/pull/195)) of this is already deployed (you can see the "entitled" field in `curl https://store.openc3.com/api/v1.2/cosmos_plugins | jq`)