### PR TITLE
-y is not a valid option for uv pip uninstall

### DIFF
--- a/openc3/lib/openc3/models/python_package_model.rb
+++ b/openc3/lib/openc3/models/python_package_model.rb
@@ -99,7 +99,7 @@ module OpenC3
     def self.destroy(name, scope:)
       package_name, version = self.extract_name_and_version(name)
       Logger.info "Uninstalling package: #{name}"
-      pip_args = ["-y", package_name]
+      pip_args = [package_name]
       result = OpenC3::ProcessManager.instance.spawn(["/openc3/bin/pipuninstall"] + pip_args, "package_uninstall", name, Time.now + 3600.0, scope: scope)
       return result.name
     end


### PR DESCRIPTION
-y is not a valid option for uv pip uninstall, this was a hold-over from the `pip` to the `uv pip` refactor.

fixes #3018