### PR TITLE
Don't raise warning when virtual environment already exists when trying to create a new one.

### DIFF
--- a/openc3/bin/pipinstall
+++ b/openc3/bin/pipinstall
@@ -4,10 +4,42 @@ echo "uv pip install $@"
 uv pip install --python "$PYTHONUSERBASE" "$@"
 if [ $? -eq 0 ]; then
     echo "Command succeeded"
-else
-    echo "Command failed - retrying with --no-index"
-    uv pip install --python "$PYTHONUSERBASE" --no-index "$@"
-    if [ $? -ne 0 ]; then
-        echo "ERROR: uv pip install failed"
+    exit 0
+fi
+
+# Collect the last arg and all preceding args
+LAST_ARG=""
+OPTS=""
+PREV=""
+for ARG in "$@"; do
+    if [ -n "$PREV" ]; then
+        OPTS="${OPTS} ${PREV}"
     fi
+    PREV="$ARG"
+done
+LAST_ARG="$PREV"
+
+# If last arg is a directory with pyproject.toml, the build may have failed
+# (e.g. Poetry package-mode = false). Try compiling and installing declared
+# dependencies only, without attempting to build the package itself.
+if [ -d "$LAST_ARG" ] && [ -f "$LAST_ARG/pyproject.toml" ]; then
+    echo "Warning: Failed to build Python package, attempting to install declared dependencies from pyproject.toml"
+    TMPFILE=$(mktemp)
+    uv pip compile ${OPTS} "${LAST_ARG}/pyproject.toml" > "$TMPFILE"
+    if [ $? -eq 0 ] && [ -s "$TMPFILE" ]; then
+        uv pip install --python "$PYTHONUSERBASE" ${OPTS} -r "$TMPFILE"
+        if [ $? -eq 0 ]; then
+            echo "Dependencies installed successfully"
+            rm -f "$TMPFILE"
+            exit 0
+        fi
+    fi
+    rm -f "$TMPFILE"
+fi
+
+echo "Warning: Install failed - retrying with --no-index"
+uv pip install --python "$PYTHONUSERBASE" --no-index "$@"
+if [ $? -ne 0 ]; then
+    echo "ERROR: uv pip install failed"
+    exit 1
 fi

--- a/openc3/lib/openc3/models/plugin_model.rb
+++ b/openc3/lib/openc3/models/plugin_model.rb
@@ -280,7 +280,15 @@ module OpenC3
                 pip_args = "-i #{pypi_url} --trusted-host #{URI.parse(pypi_url).host} -r #{requirements_path}"
               end
             end
-            puts `/openc3/bin/pipinstall #{pip_args}`
+            # Capture output and check exit code so failures surface as a warning
+            # rather than silently succeeding. pipinstall is non-fatal: the plugin
+            # continues to install even if Python packages fail so that non-Python
+            # functionality still works.
+            output = `/openc3/bin/pipinstall #{pip_args}`
+            puts output
+            unless $?.success?
+              Logger.warn "Python package installation failed. Plugin Python microservices may not function correctly."
+            end
           end
           needs_dependencies = true
         end


### PR DESCRIPTION
To prevent the error when trying to create a virtual environment that already exists, you can use the --allow-existing option with the uv venv command. This will allow you to bypass the error and use the existing environment instead.

Problem (expanded):
When installing a plugin whose pyproject.toml specifies a build backend (e.g. poetry-core) but is not structured as an installable Python package, uv pip install <gem_path> fails during the build step with a ModuleOrPackageNotFoundError. This caused a second failure when pipinstall retried with --no-index, since transitive dependencies (like openc3) couldn't be found without index access. Both errors were silently swallowed — pipinstall always exited 0, and plugin_model.rb never checked the exit code.

  Changes:
- pipinstall: Add --allow-existing to the uv venv call so installing a plugin reuses the existing virtual environment without warnings.
- pipinstall: When a build failure occurs and the target is a directory with a pyproject.toml, fall back to uv pip compile <pyproject.toml> to resolve and install the declared [project.dependencies] directly, bypassing the build backend entirely. Also fixed pipinstall to return exit code 1 on total failure.
- plugin_model.rb: Check pipinstall's exit code and emit Logger.warn so failures surface in the COSMOS UI. Installation remains non-fatal — non-Python plugin functionality still works.

Plugin note (optional):
If a plugin's pyproject.toml is not meant to produce an installable Python package (i.e. it only exists to declare dependencies for microservice scripts), the [build-system] section can be removed entirely. Without it, uv pip install <gem_path> will still fail on the first attempt, but the pipinstall fallback will handle it cleanly. Removing [build-system] just eliminates the first-attempt noise. This is a cleanup, not a requirement.

fixes #3022