### PR TITLE
Bug/template accessor

### DIFF
--- a/openc3/lib/openc3/accessors/template_accessor.rb
+++ b/openc3/lib/openc3/accessors/template_accessor.rb
@@ -53,6 +53,9 @@ module OpenC3
       return nil if item.data_type == :DERIVED
       configure()
 
+      # No template items to read (e.g. command with fixed template string)
+      return nil if @item_keys.empty?
+
       # Scan the response for all the variables in brackets <VARIABLE>
       values = buffer.scan(@read_regexp)[0]
       if !values || (values.length != @item_keys.length)
@@ -72,6 +75,12 @@ module OpenC3
     def read_items(items, buffer)
       result = {}
       configure()
+
+      # No template items to read (e.g. command with fixed template string)
+      if @item_keys.empty?
+        items.each { |item| result[item.name] = nil }
+        return result
+      end
 
       # Scan the response for all the variables in brackets <VARIABLE>
       values = buffer.scan(@read_regexp)[0]

--- a/openc3/python/openc3/accessors/template_accessor.py
+++ b/openc3/python/openc3/accessors/template_accessor.py
@@ -56,6 +56,10 @@ class TemplateAccessor(Accessor):
             return None
         self.configure()
 
+        # No template items to read (e.g. command with fixed template string)
+        if not self.item_keys:
+            return None
+
         # Scan the response for all the variables in brackets <VARIABLE>
         values = self.read_regexp.match(buffer.decode())
         if values is not None:
@@ -82,6 +86,12 @@ class TemplateAccessor(Accessor):
     def read_items(self, items, buffer):
         result = {}
         self.configure()
+
+        # No template items to read (e.g. command with fixed template string)
+        if not self.item_keys:
+            for item in items:
+                result[item.name] = None
+            return result
 
         # Scan the response for all the variables in brackets <VARIABLE>
         values = self.read_regexp.match(buffer.decode())

--- a/openc3/python/test/accessors/test_template_accessor.py
+++ b/openc3/python/test/accessors/test_template_accessor.py
@@ -95,6 +95,24 @@ class TestTemplateAccessor(unittest.TestCase):
         self.assertEqual(values["CHANNEL"], 2)
         self.assertAlmostEqual(values["MYVALUE"], 5.67, places=2)
 
+    def test_should_handle_templates_with_no_items(self):
+        packet = Packet()
+        packet.template = b"OUTPUT:STATE? (@1:3);"
+        packet.buffer = packet.template
+        accessor = TemplateAccessor(packet)
+
+        item = namedtuple("Item", ["name", "key", "data_type", "array_size"])
+        item.name = "DUMMY"
+        item.key = "DUMMY"
+        item.data_type = "STRING"
+        item.array_size = None
+
+        value = accessor.read_item(item, packet.buffer_no_copy())
+        self.assertIsNone(value)
+
+        values = accessor.read_items([item], packet.buffer_no_copy())
+        self.assertIsNone(values["DUMMY"])
+
     def test_should_write_values(self):
         accessor = TemplateAccessor(self.packet)
         self.packet.restore_defaults()

--- a/openc3/spec/accessors/template_accessor_spec.rb
+++ b/openc3/spec/accessors/template_accessor_spec.rb
@@ -94,6 +94,24 @@ module OpenC3
         expect(values['CHANNEL']).to eq 2
         expect(values['MYVALUE']).to be_within(0.01).of(5.67)
       end
+
+      it "should handle templates with no items" do
+        packet = Packet.new
+        packet.template = 'OUTPUT:STATE? (@1:3);'
+        packet.buffer = packet.template
+        accessor = TemplateAccessor.new(packet)
+
+        item = OpenStruct.new
+        item.name = 'DUMMY'
+        item.key = 'DUMMY'
+        item.data_type = :STRING
+
+        value = accessor.read_item(item, packet.buffer(false))
+        expect(value).to be_nil
+
+        values = accessor.read_items([item], packet.buffer(false))
+        expect(values['DUMMY']).to be_nil
+      end
     end
 
     describe "write_item and write_items" do


### PR DESCRIPTION
In fixed string templates, the `buffer.scan` will have no capture groups. These are some guards added to prevent those from getting called.