### PR TITLE
Fix graph time scale when there's no data to graph

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/models/logged_streaming_thread.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/logged_streaming_thread.rb
@@ -356,6 +356,7 @@ class LoggedStreamingThread < StreamingThread
         meta[:topics] << topic
 
         item = available[item_index]
+        next if item.nil? # API probably requested something that doesn't exist, so we'll ignore it and return nothing for it
         tgt, pkt, orig_item_name, value_type = item.split('__')
 
         # Check if this is a stored timestamp item (PACKET_TIMESECONDS or RECEIVED_TIMESECONDS)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
@@ -1148,6 +1148,14 @@ export default {
           max += 1
         }
         this.graph.setScale('x', { min, max })
+      } else if (this.graphStartDateTime && this.graphEndDateTime) {
+        const min = this.graphStartDateTime / 1_000_000_000
+        const max = this.graphEndDateTime / 1_000_000_000
+        this.graph.setScale('x', { min, max })
+        this.$notify.caution({
+          title: 'Empty graph data',
+          body: 'No data was returned for the selected time range.',
+        })
       }
 
       this.dataChanged = false
@@ -1407,10 +1415,17 @@ export default {
       return {
         scales: {
           x: {
-            range(u, dataMin, dataMax) {
+            range: (u, dataMin, dataMax) => {
               if (dataMin == null) {
+                if (this.graphStartDateTime && this.graphEndDateTime) {
+                  return [
+                    this.graphStartDateTime / 1_000_000_000,
+                    this.graphEndDateTime / 1_000_000_000,
+                  ]
+                }
                 if (this.xAxisIsTime) {
-                  return [1566453600, 1566497660]
+                  const now = Date.now() / 1000
+                  return [now - 3600, now] // 1hr
                 }
                 return [0, 1]
               }
@@ -1419,7 +1434,7 @@ export default {
             time: this.xAxisIsTime,
           },
           y: {
-            range(u, dataMin, dataMax) {
+            range: (u, dataMin, dataMax) => {
               if (dataMin == null) return [-100, 100]
               return uPlot.rangeNum(dataMin, dataMax, 0.1, true)
             },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
@@ -1148,9 +1148,11 @@ export default {
           max += 1
         }
         this.graph.setScale('x', { min, max })
-      } else if (this.graphStartDateTime && this.graphEndDateTime) {
+      } else if (this.graphStartDateTime) {
         const min = this.graphStartDateTime / 1_000_000_000
-        const max = this.graphEndDateTime / 1_000_000_000
+        const max = this.graphEndDateTime
+          ? this.graphEndDateTime / 1_000_000_000
+          : Date.now() / 1000
         this.graph.setScale('x', { min, max })
         this.$notify.caution({
           title: 'Empty graph data',
@@ -1417,11 +1419,11 @@ export default {
           x: {
             range: (u, dataMin, dataMax) => {
               if (dataMin == null) {
-                if (this.graphStartDateTime && this.graphEndDateTime) {
-                  return [
-                    this.graphStartDateTime / 1_000_000_000,
-                    this.graphEndDateTime / 1_000_000_000,
-                  ]
+                if (this.graphStartDateTime) {
+                  const max = this.graphEndDateTime
+                    ? this.graphEndDateTime / 1_000_000_000
+                    : Date.now() / 1000
+                  return [this.graphStartDateTime / 1_000_000_000, max]
                 }
                 if (this.xAxisIsTime) {
                   const now = Date.now() / 1000


### PR DESCRIPTION
closes #3165

- changed `range` methods to arrow functions so that the `this` is correct
- replaced hardcoded default time range to instead show the previous hour
- check for the case when no data was returned, and set the x scale manually

**Case where no data exists (set range to 4/7/2025 to 5/7/2025):**
- x-axis now shows selected time range
- graph is empty, with an alert above indicating no data
<img width="1064" height="810" alt="image" src="https://github.com/user-attachments/assets/56c825e5-62ac-4b06-9623-1be0cdbe7201" />

**Case where data only exists for one of the items for part of the range:**
- did this by connecting the EXAMPLE target in the demo, graphing its PACKET_ID, and selecting a range around when I connected it
<img width="1021" height="505" alt="image" src="https://github.com/user-attachments/assets/3dfa732e-79cc-44fd-a7dc-13c809280478" />
