### PR TITLE
Update pre-commit hook

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -22,7 +22,7 @@ Automatically ensures copyright exists and updates copyright years in modified f
 - Updates `All changes Copyright YYYY, OpenC3, Inc.` to the current year (for dual-copyright files)
 - Does NOT modify Ball Aerospace copyright lines
 - Adds the OpenC3 Copyright header to any newly created files
-- Automatically re-stages files that were updated`
+- Automatically re-stages files that were updated
 
 **Example:**
 ```ruby

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -14,14 +14,15 @@ After cloning the repository, install the hooks by running:
 
 ### pre-commit
 
-Automatically updates copyright years in modified files during commits.
+Automatically ensures copyright exists and updates copyright years in modified files during commits.
 
 **What it does:**
 - Scans all files staged for commit
 - Updates `Copyright YYYY OpenC3, Inc.` to the current year
 - Updates `All changes Copyright YYYY, OpenC3, Inc.` to the current year (for dual-copyright files)
 - Does NOT modify Ball Aerospace copyright lines
-- Automatically re-stages files with updated copyright headers
+- Adds the OpenC3 Copyright header to any newly created files
+- Automatically re-stages files that were updated`
 
 **Example:**
 ```ruby

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # Pre-commit hook to update Copyright year in modified files
+# and add copyright headers to newly created files
 
 require 'time'
 
@@ -8,6 +9,36 @@ current_year = Time.now.year
 
 # Get list of staged files
 staged_files = `git diff --cached --name-only --diff-filter=ACM`.split("\n")
+
+# Get list of newly added files (subset of staged_files)
+added_files = `git diff --cached --name-only --diff-filter=A`.split("\n")
+
+INNER_COPYRIGHT = lambda do |year|
+  <<~HEADER.chomp
+    # Copyright #{year} OpenC3, Inc.
+    # All Rights Reserved.
+    #
+    # This program is distributed in the hope that it will be useful,
+    # but WITHOUT ANY WARRANTY; without even the implied warranty of
+    # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    # See LICENSE.md for more details.
+    #
+    # This file may also be used under the terms of a commercial license
+    # if purchased from OpenC3, Inc.
+  HEADER
+end
+
+def build_copyright_header(file, year)
+  inner = INNER_COPYRIGHT.call(year)
+  case File.extname(file).downcase
+  when '.rb', '.py', '.sh', '.rake', '.gemspec', '.yaml', '.yml'
+    "#{inner}\n\n"
+  when '.js', '.ts', '.mjs', '.cjs', '.jsx', '.tsx'
+    "/*\n#{inner}\n*/\n\n"
+  when '.vue'
+    "<!--\n#{inner}\n-->\n\n"
+  end
+end
 
 # Track if any files were modified
 files_modified = false
@@ -33,8 +64,19 @@ staged_files.each do |file|
   has_copyright = content.match?(/^[#\/\*\s]*Copyright\s+\d{4}\s+OpenC3,\s+Inc\./i) ||
                   content.match?(/^[#\/\*\s]*All changes Copyright\s+\d{4},\s+OpenC3,\s+Inc\./i)
 
-  # Skip files without copyright headers
-  next unless has_copyright
+  # If no copyright and file is newly added, prepend a header
+  unless has_copyright
+    if added_files.include?(file)
+      header = build_copyright_header(file, current_year)
+      if header
+        File.write(file, header + content)
+        system("git add #{file}")
+        files_modified = true
+        puts "Added copyright header to: #{file}"
+      end
+    end
+    next
+  end
 
   # Pattern 1: Single OpenC3 copyright header
   # Match "Copyright YYYY OpenC3, Inc." and update year


### PR DESCRIPTION
Pre-commit hook will add the copyright header to any new files if it isn't present. Must re-run `cosmos/hooks/install.sh` to gain the new behavior