### PR TITLE
Update pre-commit hook and Claude rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,23 +211,6 @@ PWDEBUG=1 pnpm test:parallel --headed     # Debug mode
 
 ## Code Style
 
-### Installing Hooks
-
-After cloning the repository, install git hooks to ensure code quality and consistency:
-
-```bash
-./hooks/install.sh
-```
-
-This installs:
-
-- **pre-commit** - Automatically updates copyright years in modified files to the current year
-
-### File Headers
-
-- When modifying any file, update the "Copyright YYYY OpenC3, Inc." line in the file header to the current year (2026). Do NOT modify the Ball Aerospace copyright line.
-- The pre-commit hook automatically handles this if installed.
-
 ### Ruby
 
 - RuboCop configured in `.rubocop.yml` (many rules disabled)

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -47,8 +47,14 @@ staged_files.each do |file|
   # Skip if file doesn't exist (deleted files)
   next unless File.exist?(file)
 
+  # Only process files with specific extensions
+  next unless %w[.py .rb .ts .js .vue].include?(File.extname(file).downcase)
+
   # Skip files in the hooks directory
   next if file.start_with?('hooks/')
+
+  # Skip vendored/third-party JS files
+  next if file.start_with?('openc3-cosmos-init/plugins/packages/openc3-tool-base/public/js/')
 
   # Read file content with encoding handling
   begin

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -28,14 +28,19 @@ INNER_COPYRIGHT = lambda do |year|
   HEADER
 end
 
+HASH_COMMENT_EXTENSIONS = %w[.rb .py .sh .rake .gemspec .yaml .yml].freeze
+JS_COMMENT_EXTENSIONS = %w[.js .ts .mjs .cjs .jsx .tsx].freeze
+HTML_COMMENT_EXTENSIONS = %w[.vue].freeze
+SUPPORTED_EXTENSIONS = (HASH_COMMENT_EXTENSIONS + JS_COMMENT_EXTENSIONS + HTML_COMMENT_EXTENSIONS).freeze
+
 def build_copyright_header(file, year)
   inner = INNER_COPYRIGHT.call(year)
   case File.extname(file).downcase
-  when '.rb', '.py', '.sh', '.rake', '.gemspec', '.yaml', '.yml'
+  when *HASH_COMMENT_EXTENSIONS
     "#{inner}\n\n"
-  when '.js', '.ts', '.mjs', '.cjs', '.jsx', '.tsx'
+  when *JS_COMMENT_EXTENSIONS
     "/*\n#{inner}\n*/\n\n"
-  when '.vue'
+  when *HTML_COMMENT_EXTENSIONS
     "<!--\n#{inner}\n-->\n\n"
   end
 end
@@ -48,7 +53,7 @@ staged_files.each do |file|
   next unless File.exist?(file)
 
   # Only process files with specific extensions
-  next unless %w[.py .rb .ts .js .vue].include?(File.extname(file).downcase)
+  next unless SUPPORTED_EXTENSIONS.include?(File.extname(file).downcase)
 
   # Skip files in the hooks directory
   next if file.start_with?('hooks/')


### PR DESCRIPTION
- Claude does not need to touch Copyright headers, pre-commit hook handles it (Claude sometimes gets dates wrong anyway, and it just uses more tokens unnecessarily to have Claude do this)
- pre-commit hook now only considers files are within a list of extensions and are _not_ in the `openc3-tool-base/public/js/` folder