### PR TITLE
Disable take/release command authority buttons for unauthorized users

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/TargetsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/TargetsTab.vue
@@ -190,10 +190,7 @@ export default {
       // Check user permissions for cmd authority
       let roles = OpenC3Auth.userroles()
       for (let role of roles) {
-        if (role == 'operator') {
-          this.cmdUser = true
-          break
-        } else if (role == 'runner') {
+        if (role == 'operator' || role == 'runner') {
           this.cmdUser = true
           break
         } else if (role != 'viewer' && role != 'admin' && role != 'approver') {

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/TargetsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/TargetsTab.vue
@@ -204,9 +204,7 @@ export default {
               response.data.permissions !== undefined
             ) {
               if (
-                response.data.permissions.some(
-                  (i) => i.permission == 'cmd',
-                )
+                response.data.permissions.some((i) => i.permission == 'cmd')
               ) {
                 this.cmdUser = true
               }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/TargetsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/TargetsTab.vue
@@ -33,7 +33,7 @@
             <v-btn
               color="primary"
               class="mr-2"
-              :disabled="!commandAuthority"
+              :disabled="!commandAuthority || !cmdUser"
               data-test="take-all"
             >
               Take All Cmd Authority
@@ -60,7 +60,7 @@
             <v-btn
               color="primary"
               class="mr-2"
-              :disabled="!commandAuthority"
+              :disabled="!commandAuthority || !cmdUser"
               data-test="release-all"
             >
               Release All Cmd Authority
@@ -104,7 +104,7 @@
           v-if="item.name != 'UNKNOWN'"
           block
           color="primary"
-          :disabled="!commandAuthority"
+          :disabled="!commandAuthority || !cmdUser"
           @click="take(item.name)"
         >
           Take
@@ -117,7 +117,7 @@
           v-if="item.name != 'UNKNOWN'"
           block
           color="primary"
-          :disabled="!commandAuthority"
+          :disabled="!commandAuthority || !cmdUser"
           @click="release(item.name)"
         >
           Release
@@ -164,6 +164,7 @@ export default {
       ],
       cmdAuth: {},
       commandAuthority: false,
+      cmdUser: false,
       showUpgradeToEnterpriseDialog: false,
     }
   },
@@ -186,6 +187,33 @@ export default {
       }
     })
     if (this.enterprise) {
+      // Check user permissions for cmd authority
+      let roles = OpenC3Auth.userroles()
+      for (let role of roles) {
+        if (role == 'operator') {
+          this.cmdUser = true
+          break
+        } else if (role == 'runner') {
+          this.cmdUser = true
+          break
+        } else if (role != 'viewer' && role != 'admin' && role != 'approver') {
+          // Custom role - check permissions from backend
+          await Api.get(`/openc3-api/roles/${role}`).then((response) => {
+            if (
+              response.data !== null &&
+              response.data.permissions !== undefined
+            ) {
+              if (
+                response.data.permissions.some(
+                  (i) => i.permission == 'cmd',
+                )
+              ) {
+                this.cmdUser = true
+              }
+            }
+          })
+        }
+      }
       // Get the initial scope setting
       Api.get(`/openc3-api/scopes/${window.openc3Scope}`).then((response) => {
         if (response.data.command_authority) {
@@ -239,9 +267,9 @@ export default {
     },
     tooltipHandler(method) {
       if (this.enterprise) {
-        if (this.commandAuthority) {
+        if (this.commandAuthority && this.cmdUser) {
           this[method]()
-        } else {
+        } else if (!this.commandAuthority) {
           window.open('/tools/admin/scopes', '_blank')
         }
       } else {


### PR DESCRIPTION
## Summary

- Disables the Take/Release Command Authority buttons when the current user lacks cmd permission scope
- Checks user roles on mount: operators and runners are allowed; custom roles are checked against the backend for cmd permission
- Prevents unauthorized users from clicking authority buttons that would fail at the API level (companion to enterprise PR OpenC3/cosmos-enterprise#550 which updates the backend to use cmd scope instead of system)

## Related

- Fixes [#538](https://github.com/OpenC3/cosmos/issues/538)
- Enterprise: OpenC3/cosmos-enterprise#550

## Test plan

- Verify users with cmd scope (operator, runner) can take/release command authority
- Verify users without cmd scope (viewer) see disabled buttons
- Verify custom roles with cmd permission can take/release
- Verify custom roles without cmd permission see disabled buttons
- Verify non-enterprise (Core) behavior is unchanged