### PR TITLE
models: handle 500 Server Error when adding LABELVALUEDESC

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/models/streaming_thread.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/streaming_thread.rb
@@ -191,6 +191,7 @@ class StreamingThread
   def handle_raw_packet(buffer, objects, time)
     objects = objects_active?(objects, time)
     return nil if objects.length <= 0
+    return nil if buffer.nil?
     return {
       "__type" => "PACKET",
       "__packet" => objects[0].key,


### PR DESCRIPTION
## Summary

500 Server Error when adding LABELVALUEDESC for indexed array item to Tlm Viewer screen — modified `openc3-cosmos-cmd-tlm-api/app/models/streaming_thread.rb`.

Refs #3235

## Changes

- openc3-cosmos-cmd-tlm-api/app/models/streaming_thread.rb (+1)

## Rationale

Applied fix for 500 Server Error when adding LABELVALUEDESC for indexed array item to Tlm Viewer in `streaming_thread.rb`, where the affected behavior originates.

## Scope

1 file(s) modified. Changes isolated to listed files.

## Risk

limited to openc3-cosmos-cmd-tlm-api/app/models/streaming_thread.rb.

## Validation

Basic lint and formatting checks passed.