### PR TITLE
Partial Fix: Upgrade Batch script

### DIFF
--- a/scripts/windows/openc3_upgrade.bat
+++ b/scripts/windows/openc3_upgrade.bat
@@ -25,7 +25,7 @@ if "%1"=="-h" goto usage
 
 set TAG=%1
 
-REM Setup the cosmos remote based on IS_ENTERPRISE or if upgrading to enterprise
+REM Setup the 'cosmos' remote based on IS_ENTERPRISE or if upgrading to enterprise
 echo %1 | findstr /i "enterprise" >nul 2>&1
 if "%IS_ENTERPRISE%"=="true" (
     set UPGRADING_TO_ENTERPRISE=true
@@ -39,10 +39,10 @@ if "%UPGRADING_TO_ENTERPRISE%"=="true" (
     set COSMOS_URL=https://github.com/OpenC3/cosmos-enterprise-project.git
     git remote -v | findstr /b "cosmos " >nul 2>&1
     if !errorlevel! equ 0 (
-        echo Setting cosmos remote to the enterprise repository.
+        echo Setting 'cosmos' remote to the enterprise repository.
         git remote set-url cosmos !COSMOS_URL!
     ) else (
-        echo Adding cosmos remote for the enterprise repository.
+        echo Adding 'cosmos' remote for the enterprise repository.
         git remote add cosmos !COSMOS_URL!
     )
 
@@ -64,10 +64,10 @@ if "%UPGRADING_TO_ENTERPRISE%"=="true" (
     set COSMOS_URL=https://github.com/OpenC3/cosmos-project.git
     git remote -v | findstr /b "cosmos " >nul 2>&1
     if !errorlevel! equ 0 (
-        echo Setting cosmos remote to the core repository.
+        echo Setting 'cosmos' remote to the core repository.
         git remote set-url cosmos !COSMOS_URL!
     ) else (
-        echo Adding cosmos remote for the core repository.
+        echo Adding 'cosmos' remote for the core repository.
         git remote add cosmos !COSMOS_URL!
     )
 )
@@ -79,14 +79,14 @@ if %errorlevel% equ 0 (
     set TAG=!TAG:enterprise-=!
 )
 
-REM Fetch the latest changes from the cosmos remote
-echo Fetching latest changes from the cosmos remote.
+REM Fetch the latest changes from the 'cosmos' remote
+echo Fetching latest changes from 'cosmos' remote.
 git fetch cosmos --tags
 
 REM Check the tag is valid (native git lookup, tolerant of findstr/line-ending quirks)
 git rev-parse --verify "refs/tags/%TAG%" >nul 2>&1
 if errorlevel 1 (
-    echo Error: %TAG% is not a valid git tag.
+    echo Error: '%TAG%' is not a valid git tag.
     echo Available tags:
     git tag | sort
     goto usage
@@ -100,17 +100,17 @@ if "%2"=="--preview" (
 
 REM Apply the changes
 git diff -R "refs/tags/%TAG%" --binary | git apply --whitespace=fix --exclude="plugins/*"
-echo Applied changes from tag %1.
+echo Applied changes from tag '%1'.
 echo We recommend committing these changes to your local repository.
 echo e.g. git commit -am "Upgrade to %1"
-echo You can now run openc3.bat run to start the upgraded OpenC3 environment.
+echo You can now run 'openc3.bat run' to start the upgraded OpenC3 environment.
 echo.
 GOTO :EOF
 
 :usage
     echo Usage: openc3.bat upgrade ^<tag^> --preview
     echo e.g. openc3.bat upgrade v6.4.1
-    echo The --preview flag will show the diff without applying changes.
+    echo The '--preview' flag will show the diff without applying changes.
     if "%IS_ENTERPRISE%"=="false" (
         echo.
         echo You can also upgrade to Enterprise versions of OpenC3 if you have access

--- a/scripts/windows/openc3_upgrade.bat
+++ b/scripts/windows/openc3_upgrade.bat
@@ -16,20 +16,6 @@ if exist "%REPO_ROOT%\openc3-enterprise-traefik" (
     set IS_ENTERPRISE=false
 )
 
-REM Function to display usage
-:usage
-    echo Usage: openc3.bat upgrade ^<tag^> --preview
-    echo e.g. openc3.bat upgrade v6.4.1
-    echo The '--preview' flag will show the diff without applying changes.
-    if "%IS_ENTERPRISE%"=="false" (
-        echo.
-        echo You can also upgrade to Enterprise versions of OpenC3 if you have access
-        echo e.g. openc3.bat upgrade enterprise-v6.4.1
-        echo NOTE: Upgrading to Enterprise preserves all your existing data
-        echo but is a one-way operation and cannot be undone.
-    )
-    exit /b 1
-
 REM Check if arguments are provided
 if "%1"=="" goto usage
 
@@ -52,7 +38,7 @@ if "%IS_ENTERPRISE%"=="true" (
 if "%UPGRADING_TO_ENTERPRISE%"=="true" (
     set COSMOS_URL=https://github.com/OpenC3/cosmos-enterprise-project.git
     git remote -v | findstr /b "cosmos " >nul 2>&1
-    if %errorlevel% equ 0 (
+    if !errorlevel! equ 0 (
         echo Setting 'cosmos' remote to the enterprise repository.
         git remote set-url cosmos !COSMOS_URL!
     ) else (
@@ -77,7 +63,7 @@ if "%UPGRADING_TO_ENTERPRISE%"=="true" (
 ) else (
     set COSMOS_URL=https://github.com/OpenC3/cosmos-project.git
     git remote -v | findstr /b "cosmos " >nul 2>&1
-    if %errorlevel% equ 0 (
+    if !errorlevel! equ 0 (
         echo Setting 'cosmos' remote to the core repository.
         git remote set-url cosmos !COSMOS_URL!
     ) else (
@@ -89,7 +75,7 @@ if "%UPGRADING_TO_ENTERPRISE%"=="true" (
 REM Strip a leading "enterprise-" from the tag argument if present
 echo %1 | findstr /b /i "enterprise-" >nul 2>&1
 if %errorlevel% equ 0 (
-    set TAG=%1:enterprise-=%
+    set TAG=%1
     set TAG=!TAG:enterprise-=!
 )
 
@@ -122,3 +108,17 @@ echo We recommend committing these changes to your local repository.
 echo e.g. git commit -am "Upgrade to %1"
 echo You can now run 'openc3.bat run' to start the upgraded OpenC3 environment.
 echo.
+GOTO :EOF
+
+:usage
+    echo Usage: openc3.bat upgrade ^<tag^> --preview
+    echo e.g. openc3.bat upgrade v6.4.1
+    echo The '--preview' flag will show the diff without applying changes.
+    if "%IS_ENTERPRISE%"=="false" (
+        echo.
+        echo You can also upgrade to Enterprise versions of OpenC3 if you have access
+        echo e.g. openc3.bat upgrade enterprise-v6.4.1
+        echo NOTE: Upgrading to Enterprise preserves all your existing data
+        echo but is a one-way operation and cannot be undone.
+    )
+    exit /b 1

--- a/scripts/windows/openc3_upgrade.bat
+++ b/scripts/windows/openc3_upgrade.bat
@@ -81,11 +81,11 @@ if %errorlevel% equ 0 (
 
 REM Fetch the latest changes from the 'cosmos' remote
 echo Fetching latest changes from 'cosmos' remote.
-git fetch cosmos
+git fetch cosmos --tags
 
-REM Check the tag is valid
-git tag | findstr /x "%TAG%" >nul 2>&1
-if %errorlevel% neq 0 (
+REM Check the tag is valid (native git lookup, tolerant of findstr/line-ending quirks)
+git rev-parse --verify "refs/tags/%TAG%" >nul 2>&1
+if errorlevel 1 (
     echo Error: '%TAG%' is not a valid git tag.
     echo Available tags:
     git tag | sort

--- a/scripts/windows/openc3_upgrade.bat
+++ b/scripts/windows/openc3_upgrade.bat
@@ -25,7 +25,7 @@ if "%1"=="-h" goto usage
 
 set TAG=%1
 
-REM Setup the 'cosmos' remote based on IS_ENTERPRISE or if upgrading to enterprise
+REM Setup the cosmos remote based on IS_ENTERPRISE or if upgrading to enterprise
 echo %1 | findstr /i "enterprise" >nul 2>&1
 if "%IS_ENTERPRISE%"=="true" (
     set UPGRADING_TO_ENTERPRISE=true
@@ -39,10 +39,10 @@ if "%UPGRADING_TO_ENTERPRISE%"=="true" (
     set COSMOS_URL=https://github.com/OpenC3/cosmos-enterprise-project.git
     git remote -v | findstr /b "cosmos " >nul 2>&1
     if !errorlevel! equ 0 (
-        echo Setting 'cosmos' remote to the enterprise repository.
+        echo Setting cosmos remote to the enterprise repository.
         git remote set-url cosmos !COSMOS_URL!
     ) else (
-        echo Adding 'cosmos' remote for the enterprise repository.
+        echo Adding cosmos remote for the enterprise repository.
         git remote add cosmos !COSMOS_URL!
     )
 
@@ -64,10 +64,10 @@ if "%UPGRADING_TO_ENTERPRISE%"=="true" (
     set COSMOS_URL=https://github.com/OpenC3/cosmos-project.git
     git remote -v | findstr /b "cosmos " >nul 2>&1
     if !errorlevel! equ 0 (
-        echo Setting 'cosmos' remote to the core repository.
+        echo Setting cosmos remote to the core repository.
         git remote set-url cosmos !COSMOS_URL!
     ) else (
-        echo Adding 'cosmos' remote for the core repository.
+        echo Adding cosmos remote for the core repository.
         git remote add cosmos !COSMOS_URL!
     )
 )
@@ -79,14 +79,14 @@ if %errorlevel% equ 0 (
     set TAG=!TAG:enterprise-=!
 )
 
-REM Fetch the latest changes from the 'cosmos' remote
-echo Fetching latest changes from 'cosmos' remote.
+REM Fetch the latest changes from the cosmos remote
+echo Fetching latest changes from the cosmos remote.
 git fetch cosmos --tags
 
 REM Check the tag is valid (native git lookup, tolerant of findstr/line-ending quirks)
 git rev-parse --verify "refs/tags/%TAG%" >nul 2>&1
 if errorlevel 1 (
-    echo Error: '%TAG%' is not a valid git tag.
+    echo Error: %TAG% is not a valid git tag.
     echo Available tags:
     git tag | sort
     goto usage
@@ -100,17 +100,17 @@ if "%2"=="--preview" (
 
 REM Apply the changes
 git diff -R "refs/tags/%TAG%" --binary | git apply --whitespace=fix --exclude="plugins/*"
-echo Applied changes from tag '%1'.
+echo Applied changes from tag %1.
 echo We recommend committing these changes to your local repository.
 echo e.g. git commit -am "Upgrade to %1"
-echo You can now run 'openc3.bat run' to start the upgraded OpenC3 environment.
+echo You can now run openc3.bat run to start the upgraded OpenC3 environment.
 echo.
 GOTO :EOF
 
 :usage
     echo Usage: openc3.bat upgrade ^<tag^> --preview
     echo e.g. openc3.bat upgrade v6.4.1
-    echo The '--preview' flag will show the diff without applying changes.
+    echo The --preview flag will show the diff without applying changes.
     if "%IS_ENTERPRISE%"=="false" (
         echo.
         echo You can also upgrade to Enterprise versions of OpenC3 if you have access

--- a/scripts/windows/openc3_upgrade.bat
+++ b/scripts/windows/openc3_upgrade.bat
@@ -92,17 +92,14 @@ if errorlevel 1 (
     goto usage
 )
 
-REM Get the commit hash for the tag
-for /f "tokens=1" %%a in ('git ls-remote cosmos refs/tags/%TAG%') do set HASH=%%a
-
 REM If the --preview flag is set, show the diff without applying changes
 if "%2"=="--preview" (
-    git diff -R %HASH%
+    git diff -R "refs/tags/%TAG%"
     exit /b 0
 )
 
 REM Apply the changes
-git diff -R %HASH% | git apply --whitespace=fix --exclude="plugins/*"
+git diff -R "refs/tags/%TAG%" --binary | git apply --whitespace=fix --exclude="plugins/*"
 echo Applied changes from tag '%1'.
 echo We recommend committing these changes to your local repository.
 echo e.g. git commit -am "Upgrade to %1"


### PR DESCRIPTION
closes https://github.com/OpenC3/cosmos-enterprise/issues/555

The upgrade command was silently exiting without doing anything due to a fall-through bug in openc3_upgrade.bat. Fixed that and a few adjacent issues the fall-through was masking.                                                                                                                                                                                                                                        

The upgrade now runs end-to-end, but some Windows environments still emit spurious "X is not recognized" errors during the apply (non-deterministic, only on the non-preview path). The upgrade itself succeeds — the errors are noise. Root cause looks environmental (AV, sync daemons, or cmd.exe quirks);

Workaround if the errors block a user: run the git commands directly —
`git fetch cosmos --tags` then `git diff -R refs/tags/<tag> --binary |  git apply --whitespace=fix --exclude="plugins/*"`.