### PR TITLE
Make VARIABLE_STATE description optional

### DIFF
--- a/openc3/lib/openc3/models/plugin_model.rb
+++ b/openc3/lib/openc3/models/plugin_model.rb
@@ -158,12 +158,12 @@ module OpenC3
             variables[current_variable_name]['description'] = params[0]
           when 'VARIABLE_STATE'
             usage = "#{keyword} <Display Text> <Value>"
-            parser.verify_num_parameters(2, 2, usage)
+            parser.verify_num_parameters(1, 2, usage)
             unless current_variable_name
               raise "VARIABLE_STATE must follow a VARIABLE definition"
             end
             variables[current_variable_name]['options'] ||= []
-            option = { 'value' => params[1], 'text' => params[0] }
+            option = { 'value' => params[1] || params[0], 'text' => params[0] }
             variables[current_variable_name]['options'] << option
           end
         end


### PR DESCRIPTION
Docs say that state description is optional (https://docs.openc3.com/docs/configuration/plugins#variable_state), but the code currently enforces that you must pass 2 parameters.

This PR makes behavior match documentation. (If we don't proceed with this PR, docs should be updated to match behavior)