### PR TITLE
fix(anycable): prevent gRPC keepalive too_many_pings GoAway

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/config/initializers/anycable.rb
+++ b/openc3-cosmos-cmd-tlm-api/config/initializers/anycable.rb
@@ -1,0 +1,28 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+# anycable-go's gRPC client sends keepalive pings every 10s (hardcoded in
+# keepalive.ClientParameters.Time). AnyCable's default server enforcement
+# (min_recv_ping_interval_without_data_ms = 10_000) matches the client
+# exactly, so normal scheduling jitter can make a ping arrive just under the
+# threshold and accumulate strikes until the server emits
+# GoAway ENHANCE_YOUR_CALM "too_many_pings", tearing down active RPCs.
+# Halving the server minimum gives 5s of jitter tolerance against the fixed
+# 10s client interval. See grpc/grpc#25713 and doc/keepalive.md.
+AnyCable.configure do |config|
+  config.rpc_server_args = {
+    "grpc.keepalive_permit_without_calls" => 1,
+    "grpc.http2.min_recv_ping_interval_without_data_ms" => 5_000,
+    "grpc.http2.min_ping_interval_without_data_ms" => 5_000,
+  }
+end

--- a/openc3-cosmos-cmd-tlm-api/config/initializers/anycable.rb
+++ b/openc3-cosmos-cmd-tlm-api/config/initializers/anycable.rb
@@ -13,7 +13,7 @@
 
 # anycable-go's gRPC client sends keepalive pings every 10s (hardcoded in
 # keepalive.ClientParameters.Time). AnyCable's default server enforcement
-# (min_recv_ping_interval_without_data_ms = 10_000) matches the client
+# (min_ping_interval_without_data_ms = 10_000) matches the client
 # exactly, so normal scheduling jitter can make a ping arrive just under the
 # threshold and accumulate strikes until the server emits
 # GoAway ENHANCE_YOUR_CALM "too_many_pings", tearing down active RPCs.
@@ -22,7 +22,6 @@
 AnyCable.configure do |config|
   config.rpc_server_args = {
     "grpc.keepalive_permit_without_calls" => 1,
-    "grpc.http2.min_recv_ping_interval_without_data_ms" => 5_000,
     "grpc.http2.min_ping_interval_without_data_ms" => 5_000,
   }
 end

--- a/openc3-cosmos-script-runner-api/config/initializers/anycable.rb
+++ b/openc3-cosmos-script-runner-api/config/initializers/anycable.rb
@@ -1,0 +1,28 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+# anycable-go's gRPC client sends keepalive pings every 10s (hardcoded in
+# keepalive.ClientParameters.Time). AnyCable's default server enforcement
+# (min_recv_ping_interval_without_data_ms = 10_000) matches the client
+# exactly, so normal scheduling jitter can make a ping arrive just under the
+# threshold and accumulate strikes until the server emits
+# GoAway ENHANCE_YOUR_CALM "too_many_pings", tearing down active RPCs.
+# Halving the server minimum gives 5s of jitter tolerance against the fixed
+# 10s client interval. See grpc/grpc#25713 and doc/keepalive.md.
+AnyCable.configure do |config|
+  config.rpc_server_args = {
+    "grpc.keepalive_permit_without_calls" => 1,
+    "grpc.http2.min_recv_ping_interval_without_data_ms" => 5_000,
+    "grpc.http2.min_ping_interval_without_data_ms" => 5_000,
+  }
+end

--- a/openc3-cosmos-script-runner-api/config/initializers/anycable.rb
+++ b/openc3-cosmos-script-runner-api/config/initializers/anycable.rb
@@ -13,7 +13,7 @@
 
 # anycable-go's gRPC client sends keepalive pings every 10s (hardcoded in
 # keepalive.ClientParameters.Time). AnyCable's default server enforcement
-# (min_recv_ping_interval_without_data_ms = 10_000) matches the client
+# (min_ping_interval_without_data_ms = 10_000) matches the client
 # exactly, so normal scheduling jitter can make a ping arrive just under the
 # threshold and accumulate strikes until the server emits
 # GoAway ENHANCE_YOUR_CALM "too_many_pings", tearing down active RPCs.
@@ -22,7 +22,6 @@
 AnyCable.configure do |config|
   config.rpc_server_args = {
     "grpc.keepalive_permit_without_calls" => 1,
-    "grpc.http2.min_recv_ping_interval_without_data_ms" => 5_000,
     "grpc.http2.min_ping_interval_without_data_ms" => 5_000,
   }
 end


### PR DESCRIPTION
AnyCable's default server min_recv_ping_interval_without_data_ms (10_000ms) matches anycable-go's hardcoded 10s client keepalive exactly. Jitter causes pings to arrive under the threshold, accumulating strikes and emitting GoAway ENHANCE_YOUR_CALM that tears down active RPCs (closes #3240). Halve the server minimum to 5_000ms for jitter tolerance.