### PR TITLE
Correctly parse array items in various widgets

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/screens/array.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/screens/array.txt
@@ -3,8 +3,13 @@ SCREEN AUTO AUTO 1.0
 VERTICAL
   TITLE "<%= target_name %> Instrument Array Data"
   ARRAY <%= target_name %> HEALTH_STATUS ARY
+  LABELVALUE <%= target_name %> HEALTH_STATUS ARY
   LABELVALUE <%= target_name %> HEALTH_STATUS ARY[0] RAW
   LABELVALUE <%= target_name %> HEALTH_STATUS ARY[1] FORMATTED
+  LABELVALUEDESC <%= target_name %> HEALTH_STATUS ARY
+  LABELVALUEDESC <%= target_name %> HEALTH_STATUS ARY "Full Array"
+  LABELVALUEDESC <%= target_name %> HEALTH_STATUS ARY[0]
+  LABELVALUEDESC <%= target_name %> HEALTH_STATUS ARY[0] "Array Item"
   # This item is actually called BRACKET[0] as the name
   # thus we have to escape the value here to avoid it
   # being treated like an array item

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/screens/array.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/screens/array.txt
@@ -3,8 +3,13 @@ SCREEN AUTO AUTO 1.0
 VERTICAL
   TITLE "<%= target_name %> Instrument Array Data"
   ARRAY <%= target_name %> HEALTH_STATUS ARY
+  LABELVALUE <%= target_name %> HEALTH_STATUS ARY
   LABELVALUE <%= target_name %> HEALTH_STATUS ARY[0] RAW
   LABELVALUE <%= target_name %> HEALTH_STATUS ARY[1] FORMATTED
+  LABELVALUEDESC <%= target_name %> HEALTH_STATUS ARY
+  LABELVALUEDESC <%= target_name %> HEALTH_STATUS ARY "Full Array"
+  LABELVALUEDESC <%= target_name %> HEALTH_STATUS ARY[0]
+  LABELVALUEDESC <%= target_name %> HEALTH_STATUS ARY[0] "Array Item"
   # This item is actually called BRACKET[0] as the name
   # thus we have to escape the value here to avoid it
   # being treated like an array item

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/BarColumn.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/BarColumn.js
@@ -68,16 +68,11 @@ export default {
   created() {
     this.api = new OpenC3Api()
 
-    // Remove double bracket escaping. This means they actually have an item
-    // with a bracket in the name, not an array index.
-    if (this.parameters[2].includes('[[')) {
-      this.parameters[2] = this.parameters[2]
-        .replace('[[', '[')
-        .replace(']]', ']')
-    }
+    const parsed = this.parseItemName(this.parameters[2])
+    this.parameters[2] = parsed.name
 
     this.api
-      .get_limits(this.parameters[0], this.parameters[1], this.parameters[2])
+      .get_limits(this.parameters[0], this.parameters[1], parsed.name)
       .then((data) => {
         this.limitsSettings = data
       })

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/GraphWidget.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/GraphWidget.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -111,25 +111,18 @@ export default {
       }
     })
     this.items = this.items.map((item) => {
-      let itemName = item.itemName
-      // Remove double bracket escaping. This means they actually have an item
-      // with a bracket in the name, not an array index.
-      if (item.itemName.includes('[[')) {
-        // Change the actual item and the the name we're passing to the screen
-        item.itemName = item.itemName.replace('[[', '[').replace(']]', ']')
-        itemName = item.itemName
-      } else if (item.itemName.includes('[')) {
-        // Brackets mean array indexes (normally, but see above)
-        let match = item.itemName.match(/\[(\d+)\]/)
-        this.arrayIndex = parseInt(match[1])
-        // Here we keep the original item name with the brackets but change
-        // the item we're passing to the screen to the non-bracket item
-        itemName = item.itemName.replace(match[0], '')
+      const parsed = this.parseItemName(item.itemName)
+      if (parsed.arrayIndex !== null) {
+        // Keep the original bracketed name on the item; record the index so
+        // downstream consumers can pick the element.
+        this.arrayIndex = parsed.arrayIndex
+      } else {
+        // Un-escape [[...]] for real items whose names contain brackets;
+        // a no-op for plain names.
+        item.itemName = parsed.name
       }
       // We don't emit 'addItem' because graphWidgets use streams in realtime
       // and manage their own playback requests
-
-      // Return the mapped values since we may have removed bracket escaping
       return item
     })
   },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LabelvalueWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LabelvalueWidget.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -50,15 +50,9 @@ export default {
   mixins: [Widget],
   computed: {
     labelName() {
-      let label = this.parameters[2]
-      // Remove double bracket escaping. This means they actually have an item
-      // with a bracket in the name, not an array index.
-      if (label.includes('[[')) {
-        label = label.replace('[[', '[').replace(']]', ']')
-      }
       // LabelWidget uses index 0 from the parameters prop
       // so create an array with the label text in the first position
-      return [label + ':']
+      return [this.parseItemName(this.parameters[2]).display + ':']
     },
     valueParameters() {
       return [

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LabelvaluedescWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LabelvaluedescWidget.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2025, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -71,11 +71,18 @@ export default {
     if (this.parameters.length > 3) {
       this.description = this.parameters[3]
     } else {
-      new OpenC3Api()
-        .get_item(this.parameters[0], this.parameters[1], this.parameters[2])
-        .then((details) => {
-          this.description = details['description']
-        })
+      const parsed = this.parseItemName(this.parameters[2])
+      if (parsed.arrayIndex !== null) {
+        // Array elements have no per-element description; fall back to the
+        // item name as the label, matching the LABELVALUE default.
+        this.description = parsed.display
+      } else {
+        new OpenC3Api()
+          .get_item(this.parameters[0], this.parameters[1], parsed.name)
+          .then((details) => {
+            this.description = details['description']
+          })
+      }
     }
   },
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/VWidget.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/VWidget.js
@@ -171,18 +171,9 @@ export default {
   created() {
     // If they're not passing us the value and limitsState we have to register
     if (this.value === null || this.limitsState === null) {
-      // Remove double bracket escaping. This means they actually have an item
-      // with a bracket in the name, not an array index.
-      if (this.parameters[2].includes('[[')) {
-        this.parameters[2] = this.parameters[2]
-          .replace('[[', '[')
-          .replace(']]', ']')
-      } else if (this.parameters[2].includes('[')) {
-        // Brackets mean array indexes (normally, but see above)
-        let match = this.parameters[2].match(/\[(\d+)\]/)
-        this.arrayIndex = parseInt(match[1])
-        this.parameters[2] = this.parameters[2].replace(match[0], '')
-      }
+      const parsed = this.parseItemName(this.parameters[2])
+      this.parameters[2] = parsed.name
+      this.arrayIndex = parsed.arrayIndex
       this.valueId = `${this.parameters[0]}__${this.parameters[1]}__${
         this.parameters[2]
       }__${this.getType()}`

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/Widget.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/Widget.js
@@ -313,5 +313,30 @@ export default {
     toQualifiedWidgetName(widgetName) {
       return `${this.screenId}:${widgetName}`
     },
+    // Parse a screen-definition item name into its semantic parts.
+    //   ITEM        → plain item
+    //   ITEM[0]     → array element (single brackets = array index)
+    //   ITEM[[0]]   → escape for a real item literally named ITEM[0]
+    //
+    // Returns { name, arrayIndex, display }:
+    //   name:       item name for API lookups — brackets un-escaped and any
+    //               array index stripped, so the server can always resolve it.
+    //   arrayIndex: numeric array index, or null.
+    //   display:    user-facing name — brackets un-escaped, array index kept.
+    parseItemName(itemName) {
+      if (itemName.includes('[[')) {
+        const unescaped = itemName.replaceAll('[[', '[').replaceAll(']]', ']')
+        return { name: unescaped, arrayIndex: null, display: unescaped }
+      }
+      const match = itemName.match(/\[(\d+)\]/)
+      if (match) {
+        return {
+          name: itemName.replace(match[0], ''),
+          arrayIndex: Number.parseInt(match[1]),
+          display: itemName,
+        }
+      }
+      return { name: itemName, arrayIndex: null, display: itemName }
+    },
   },
 }


### PR DESCRIPTION
Create a new `parseItemName` in Widget.js which other widgets can call to do parse of item names and correctly escape the double brackets and pull out array indexes.

closes #3235
closes #3236