### PR TITLE
Address template injection issues

### DIFF
--- a/.github/workflows/post_release_clamav.yml
+++ b/.github/workflows/post_release_clamav.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Need write permission to upload release asset
+    env:
+      VERSION: ${{ github.event.inputs.version }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -44,53 +46,57 @@ jobs:
         run: mkdir scripts/release/clamav_results
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date -u '+%m_%d_%y_%H_%M_%S')"
+        run: echo "date=$(date -u '+%m_%d_%y_%H_%M_%S')" >> "$GITHUB_OUTPUT"
       - name: ClamAV setup and update definitions
         # This `shell` line is required to get around a known issue: https://github.com/actions/runner/issues/241#issuecomment-745902718
         shell: 'script -q -e -c "bash {0}"'
         run: ./scripts/release/clamav_setup.sh
       - name: ClamAV scan image ruby
-        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-ruby:${{ github.event.inputs.version }} pull clamav_results/openc3-ruby.txt
+        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-ruby:"$VERSION" pull clamav_results/openc3-ruby.txt
         working-directory: scripts/release
       - name: ClamAV scan image node
-        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-node:${{ github.event.inputs.version }} pull clamav_results/openc3-node.txt
+        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-node:"$VERSION" pull clamav_results/openc3-node.txt
         working-directory: scripts/release
       - name: ClamAV scan image base
-        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-base:${{ github.event.inputs.version }} pull clamav_results/openc3-base.txt
+        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-base:"$VERSION" pull clamav_results/openc3-base.txt
         working-directory: scripts/release
       - name: ClamAV scan image init
-        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-cosmos-init:${{ github.event.inputs.version }} pull clamav_results/openc3-cosmos-init.txt
+        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-cosmos-init:"$VERSION" pull clamav_results/openc3-cosmos-init.txt
         working-directory: scripts/release
       - name: ClamAV scan image redis
-        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-redis:${{ github.event.inputs.version }} pull clamav_results/openc3-redis.txt
+        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-redis:"$VERSION" pull clamav_results/openc3-redis.txt
         working-directory: scripts/release
       - name: ClamAV scan image bucket
-        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-buckets:${{ github.event.inputs.version }} pull clamav_results/openc3-buckets.txt
+        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-buckets:"$VERSION" pull clamav_results/openc3-buckets.txt
         working-directory: scripts/release
       - name: ClamAV scan image tsdb
-        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-tsdb:${{ github.event.inputs.version }} pull clamav_results/openc3-tsdb.txt
+        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-tsdb:"$VERSION" pull clamav_results/openc3-tsdb.txt
         working-directory: scripts/release
       - name: ClamAV scan image operator
-        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-operator:${{ github.event.inputs.version }} pull clamav_results/openc3-operator.txt
+        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-operator:"$VERSION" pull clamav_results/openc3-operator.txt
         working-directory: scripts/release
       - name: ClamAV scan image cmd-tlm-api
-        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-cosmos-cmd-tlm-api:${{ github.event.inputs.version }} pull clamav_results/openc3-cosmos-cmd-tlm-api.txt
+        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-cosmos-cmd-tlm-api:"$VERSION" pull clamav_results/openc3-cosmos-cmd-tlm-api.txt
         working-directory: scripts/release
       - name: ClamAV scan image script-runner-api
-        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-cosmos-script-runner-api:${{ github.event.inputs.version }} pull clamav_results/openc3-cosmos-script-runner-api.txt
+        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-cosmos-script-runner-api:"$VERSION" pull clamav_results/openc3-cosmos-script-runner-api.txt
         working-directory: scripts/release
       - name: ClamAV scan image traefik
-        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-traefik:${{ github.event.inputs.version }} pull clamav_results/openc3-traefik.txt
+        run: ruby clamav_scan_image.rb docker.io/openc3inc/openc3-traefik:"$VERSION" pull clamav_results/openc3-traefik.txt
         working-directory: scripts/release
       - name: Create zip of clamav results
         run: zip -r clamav_results.zip clamav_results
         working-directory: scripts/release
       - name: Upload release attachment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DATE: ${{ steps.date.outputs.date }}
         with:
           script: |
             const fs = require('fs');
-            const tag = "v${{ github.event.inputs.version }}"
+            const version = process.env.VERSION;
+            const date = process.env.DATE;
+            const tag = `v${version}`;
             // const tag = context.ref.replace("refs/tags/", "");
             console.log("tag = ", tag);
             // Get release for this tag
@@ -104,6 +110,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: release.data.id,
-              name: "${{ steps.date.outputs.date }}_clamav_results_v${{ github.event.inputs.version }}.zip",
+              name: `${date}_clamav_results_v${version}.zip`,
               data: await fs.readFileSync("scripts/release/clamav_results.zip")
             });

--- a/.github/workflows/post_release_trivy.yml
+++ b/.github/workflows/post_release_trivy.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Need write permission to upload release asset
+    env:
+      VERSION: ${{ github.event.inputs.version }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -44,11 +46,11 @@ jobs:
         run: mkdir sbom
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date -u '+%m_%d_%y_%H_%M_%S')"
+        run: echo "date=$(date -u '+%m_%d_%y_%H_%M_%S')" >> "$GITHUB_OUTPUT"
       - name: Run Trivy on image ruby
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-ruby:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-ruby:${{ env.VERSION }}"
           format: "json"
           output: "trivy_results/openc3-ruby.json"
           ignore-unfixed: true
@@ -57,13 +59,13 @@ jobs:
       - name: Run Trivy on image ruby in SBOM mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-ruby:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-ruby:${{ env.VERSION }}"
           format: "cyclonedx"
           output: "sbom/openc3-ruby.sbom.json"
       - name: Run Trivy on image node
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-node:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-node:${{ env.VERSION }}"
           format: "json"
           output: "trivy_results/openc3-node.json"
           ignore-unfixed: true
@@ -72,13 +74,13 @@ jobs:
       - name: Run Trivy on image node in SBOM mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-node:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-node:${{ env.VERSION }}"
           format: "cyclonedx"
           output: "sbom/openc3-node.sbom.json"
       - name: Run Trivy on image base
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-base:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-base:${{ env.VERSION }}"
           format: "json"
           output: "trivy_results/openc3-base.json"
           ignore-unfixed: true
@@ -87,13 +89,13 @@ jobs:
       - name: Run Trivy on image base in SBOM mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-base:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-base:${{ env.VERSION }}"
           format: "cyclonedx"
           output: "sbom/openc3-base.sbom.json"
       - name: Run Trivy on image cosmos-init
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-cosmos-init:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-cosmos-init:${{ env.VERSION }}"
           format: "json"
           output: "trivy_results/openc3-cosmos-init.json"
           ignore-unfixed: true
@@ -102,13 +104,13 @@ jobs:
       - name: Run Trivy on image cosmos-init in SBOM mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-cosmos-init:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-cosmos-init:${{ env.VERSION }}"
           format: "cyclonedx"
           output: "sbom/openc3-cosmos-init.sbom.json"
       - name: Run Trivy on image redis
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-redis:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-redis:${{ env.VERSION }}"
           format: "json"
           output: "trivy_results/openc3-redis.json"
           ignore-unfixed: true
@@ -117,13 +119,13 @@ jobs:
       - name: Run Trivy on image redis in SBOM mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-redis:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-redis:${{ env.VERSION }}"
           format: "cyclonedx"
           output: "sbom/openc3-redis.sbom.json"
       - name: Run Trivy on image bucket
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-buckets:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-buckets:${{ env.VERSION }}"
           format: "json"
           output: "trivy_results/openc3-buckets.json"
           ignore-unfixed: true
@@ -132,13 +134,13 @@ jobs:
       - name: Run Trivy on image bucket in SBOM mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-buckets:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-buckets:${{ env.VERSION }}"
           format: "cyclonedx"
           output: "sbom/openc3-buckets.sbom.json"
       - name: Run Trivy on image tsdb
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-tsdb:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-tsdb:${{ env.VERSION }}"
           format: "json"
           output: "trivy_results/openc3-tsdb.json"
           ignore-unfixed: true
@@ -147,13 +149,13 @@ jobs:
       - name: Run Trivy on image tsdb in SBOM mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-tsdb:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-tsdb:${{ env.VERSION }}"
           format: "cyclonedx"
           output: "sbom/openc3-tsdb.sbom.json"
       - name: Run Trivy on image operator
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-operator:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-operator:${{ env.VERSION }}"
           format: "json"
           output: "trivy_results/openc3-operator.json"
           ignore-unfixed: true
@@ -162,13 +164,13 @@ jobs:
       - name: Run Trivy on image operator in SBOM mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-operator:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-operator:${{ env.VERSION }}"
           format: "cyclonedx"
           output: "sbom/openc3-operator.sbom.json"
       - name: Run Trivy on image cmd-tlm-api
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-cosmos-cmd-tlm-api:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-cosmos-cmd-tlm-api:${{ env.VERSION }}"
           format: "json"
           output: "trivy_results/openc3-cosmos-cmd-tlm-api.json"
           ignore-unfixed: true
@@ -177,13 +179,13 @@ jobs:
       - name: Run Trivy on image cosmos-cmd-tlm-api in SBOM mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-cosmos-cmd-tlm-api:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-cosmos-cmd-tlm-api:${{ env.VERSION }}"
           format: "cyclonedx"
           output: "sbom/openc3-cosmos-cmd-tlm-api.sbom.json"
       - name: Run Trivy on image script-runner-api
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-cosmos-script-runner-api:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-cosmos-script-runner-api:${{ env.VERSION }}"
           format: "json"
           output: "trivy_results/openc3-cosmos-script-runner-api.json"
           ignore-unfixed: true
@@ -192,13 +194,13 @@ jobs:
       - name: Run Trivy on image cosmos-script-runner-api in SBOM mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-cosmos-script-runner-api:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-cosmos-script-runner-api:${{ env.VERSION }}"
           format: "cyclonedx"
           output: "sbom/openc3-cosmos-script-runner-api.sbom.json"
       - name: Run Trivy on image traefik
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-traefik:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-traefik:${{ env.VERSION }}"
           format: "json"
           output: "trivy_results/openc3-traefik.json"
           ignore-unfixed: true
@@ -207,7 +209,7 @@ jobs:
       - name: Run Trivy on image traefik in SBOM mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          image-ref: "docker.io/openc3inc/openc3-traefik:${{ github.event.inputs.version }}"
+          image-ref: "docker.io/openc3inc/openc3-traefik:${{ env.VERSION }}"
           format: "cyclonedx"
           output: "sbom/openc3-traefik.sbom.json"
       - name: Create zip of trivy results
@@ -216,10 +218,14 @@ jobs:
         run: zip -r sbom.zip sbom
       - name: Upload release attachments
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DATE: ${{ steps.date.outputs.date }}
         with:
           script: |
             const fs = require('fs');
-            const tag = "v${{ github.event.inputs.version }}"
+            const version = process.env.VERSION;
+            const date = process.env.DATE;
+            const tag = `v${version}`;
             // const tag = context.ref.replace("refs/tags/", "");
             console.log("tag = ", tag);
             // Get release for this tag
@@ -233,7 +239,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: release.data.id,
-              name: "${{ steps.date.outputs.date }}_trivy_results_v${{ github.event.inputs.version }}.zip",
+              name: `${date}_trivy_results_v${version}.zip`,
               data: await fs.readFileSync("trivy_results.zip")
             });
             // Upload the release asset
@@ -241,6 +247,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: release.data.id,
-              name: "${{ steps.date.outputs.date }}_sbom_v${{ github.event.inputs.version }}.zip",
+              name: `${date}_sbom_v${version}.zip`,
               data: await fs.readFileSync("sbom.zip")
             });


### PR DESCRIPTION
According to Aikido this addresses the following:

"A GitHub Actions workflow step contains a template expression referencing potentially untrusted GitHub context fields. This may allow malicious input to be injected into shell commands, leading to a potential supply chain attack as tokens of the CI/CD pipeline could be exfiltrated."

Even though `workflow_dispatch` requires write access to trigger, scanners flag this because the input is interpolated as raw text into the script before it runs, allowing shell/JS injection. So fix to avoid the warnings.
