### PR TITLE
Fix QuestDB 422 errors from cmd-tlm-api

### DIFF
--- a/openc3/lib/openc3/utilities/questdb_client.rb
+++ b/openc3/lib/openc3/utilities/questdb_client.rb
@@ -81,18 +81,25 @@ module OpenC3
     def self.connection(db_shard: 0)
       conns = @thread_conns.value
       conn = conns[db_shard]
-      if conn.nil? || conn.finished?
-        conn = PG::Connection.new(
-          host: hostname_for_db_shard(db_shard),
-          port: ENV['OPENC3_TSDB_QUERY_PORT'],
-          user: ENV['OPENC3_TSDB_USERNAME'],
-          password: ENV['OPENC3_TSDB_PASSWORD'],
-          dbname: 'qdb'
-        )
-        conn.type_map_for_results = PG::BasicTypeMapForResults.new(conn)
-        conns[db_shard] = conn
-        @thread_conns.value = conns
+      if conn and not conn.finished?
+        begin
+          conn.check_socket
+          return conn
+        rescue
+          # Will need to reconnect
+          conn = nil
+        end
       end
+      conn = PG::Connection.new(
+        host: hostname_for_db_shard(db_shard),
+        port: ENV['OPENC3_TSDB_QUERY_PORT'],
+        user: ENV['OPENC3_TSDB_USERNAME'],
+        password: ENV['OPENC3_TSDB_PASSWORD'],
+        dbname: 'qdb'
+      )
+      conn.type_map_for_results = PG::BasicTypeMapForResults.new(conn)
+      conns[db_shard] = conn
+      @thread_conns.value = conns
       conn
     end
 

--- a/openc3/lib/openc3/utilities/questdb_client.rb
+++ b/openc3/lib/openc3/utilities/questdb_client.rb
@@ -87,7 +87,6 @@ module OpenC3
           return conn
         rescue
           # Will need to reconnect
-          conn = nil
         end
       end
       conn = PG::Connection.new(


### PR DESCRIPTION
Checks if the socket has been closed before using and creates a new connection when needed.
I believe this is due to idle timeouts from connections in Rails worker threads that go idle between uses.