### PR TITLE
ci(build): cache COSMOS images via GHCR (build once, pull elsewhere)

### DIFF
--- a/.github/actions/build-cosmos/action.yml
+++ b/.github/actions/build-cosmos/action.yml
@@ -1,18 +1,23 @@
 name: Build COSMOS
 description: |
-  Build all COSMOS Docker images, with GHCR-backed caching.
+  Build COSMOS Docker images with per-image GHCR-backed caching.
 
-  On cache hit (image-input hash matches a previously-pushed cache), pulls the
-  11 prebuilt images from ghcr.io/openc3/openc3-{name}-buildcache:cache-<hash>
-  and retags them as docker.io/openc3inc/openc3-{name}:<tag>. On cache miss
-  (or first push of the input-hash), runs `./openc3.sh build` and pushes the
-  resulting images to GHCR for future runs.
+  Each image's cache key is a hash of (its own context paths) + (its parent
+  images' hashes, chained) + (global build inputs: compose.yaml,
+  compose-build.yaml, .env). A change to one image (e.g. openc3-traefik)
+  only invalidates that image's cache; an openc3-base change invalidates
+  openc3-base and its 4 children but leaves the 6 unrelated images cached.
 
-  This is the "build once, pull elsewhere" pattern. Local developer builds
-  are unaffected — they continue to use `./openc3.sh build` directly.
+  On per-image hit: pull ghcr.io/openc3/${img}-buildcache:cache-<hash> and
+  retag as docker.io/openc3inc/${img}:${tag}. On miss: rebuild only the
+  missed services in topological order; pulled parents satisfy their FROM
+  lines locally without being rebuilt. After the build, only the newly
+  built images are pushed to GHCR.
 
-  The cleanup workflow at .github/workflows/cleanup-ghcr.yml prunes old cache
-  entries nightly so the *-buildcache packages don't accumulate.
+  Local developer builds via ./openc3.sh build are unaffected.
+
+  The cleanup workflow at .github/workflows/cleanup-ghcr.yml prunes old
+  cache entries nightly so the *-buildcache packages don't accumulate.
 
 inputs:
   tag:
@@ -23,22 +28,45 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Compute image-input hash
-      id: hash
+    - name: Compute per-image hashes
       shell: bash
-      # Hash everything that affects image content. Using `git ls-tree` (vs
-      # hashFiles) keeps the input list maintainable and ignores untracked
-      # build artifacts. The 12-char prefix is plenty for collision avoidance
-      # given our scale.
+      # Spec rows are <name>|<context paths>|<parent images>, in topological
+      # order (parents before children). Each image's hash chains its parents'
+      # hashes so a base change cascades. 12 hex chars is plenty at our scale.
       run: |
-        HASH=$(git ls-tree -r HEAD \
-          openc3-ruby openc3 openc3-node openc3-buckets openc3-tsdb openc3-redis \
-          openc3-cosmos-cmd-tlm-api openc3-cosmos-script-runner-api openc3-operator \
-          openc3-traefik openc3-cosmos-init docs.openc3.com \
-          compose.yaml compose-build.yaml .env \
+        set -e
+        common=$(git ls-tree -r HEAD compose.yaml compose-build.yaml .env \
           | sha256sum | cut -c1-12)
-        echo "hash=$HASH" >> "$GITHUB_OUTPUT"
-        echo "Image-input hash: $HASH"
+
+        declare -A HASH
+        : > "$RUNNER_TEMP/cosmos-images.env"
+
+        while IFS='|' read -r name ctx_str parents_str; do
+          [ -z "$name" ] && continue
+          read -ra ctx <<< "$ctx_str"
+          own=$(git ls-tree -r HEAD "${ctx[@]}" | sha256sum | cut -c1-12)
+          parent_hashes=""
+          for p in $parents_str; do
+            parent_hashes="$parent_hashes ${HASH[$p]}"
+          done
+          h=$(printf '%s %s %s' "$common" "$own" "$parent_hashes" \
+            | sha256sum | cut -c1-12)
+          HASH[$name]=$h
+          echo "${name}=${h}" >> "$RUNNER_TEMP/cosmos-images.env"
+          echo "Hash[$name] = $h"
+        done <<'EOF'
+        openc3-ruby|openc3-ruby|
+        openc3-buckets|openc3-buckets|
+        openc3-tsdb|openc3-tsdb|
+        openc3-redis|openc3-redis|
+        openc3-traefik|openc3-traefik|
+        openc3-base|openc3|openc3-ruby
+        openc3-node|openc3-node|openc3-base
+        openc3-cosmos-cmd-tlm-api|openc3-cosmos-cmd-tlm-api|openc3-base
+        openc3-cosmos-script-runner-api|openc3-cosmos-script-runner-api|openc3-base
+        openc3-operator|openc3-operator|openc3-base
+        openc3-cosmos-init|openc3-cosmos-init docs.openc3.com|openc3-node openc3-base
+        EOF
 
     - name: Login to GHCR
       shell: bash
@@ -48,60 +76,80 @@ runs:
         echo "$GH_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin \
           || echo "::warning::GHCR login failed (likely a fork PR); cache pull/push will be skipped"
 
-    - name: Try GHCR cache pull
-      id: pull
+    - name: Pull cached images
       shell: bash
       env:
-        IMAGES: openc3-ruby openc3-base openc3-node openc3-buckets openc3-tsdb openc3-redis openc3-cosmos-cmd-tlm-api openc3-cosmos-script-runner-api openc3-operator openc3-traefik openc3-cosmos-init
-        CACHE_TAG: cache-${{ steps.hash.outputs.hash }}
         TAG: ${{ inputs.tag }}
+      # For each image, attempt to pull its per-hash cache tag. On hit, retag
+      # to docker.io/openc3inc/${name}:${TAG} so it serves as a local FROM
+      # source for any downstream miss. Misses are recorded for the build step.
       run: |
         set -e
-        miss=false
-        for img in $IMAGES; do
-          if ! docker pull "ghcr.io/openc3/${img}-buildcache:${CACHE_TAG}"; then
-            echo "::notice::Cache miss for ${img}:${CACHE_TAG}"
-            miss=true
-            break
+        : > "$RUNNER_TEMP/cosmos-misses.txt"
+        hits=0
+        misses=0
+        while IFS='=' read -r name hash; do
+          [ -z "$name" ] && continue
+          src="ghcr.io/openc3/${name}-buildcache:cache-${hash}"
+          if docker pull "$src" 2>/dev/null; then
+            docker tag "$src" "docker.io/openc3inc/${name}:${TAG}"
+            hits=$((hits+1))
+            echo "::notice::Cache HIT  ${name} (${hash})"
+          else
+            echo "$name" >> "$RUNNER_TEMP/cosmos-misses.txt"
+            misses=$((misses+1))
+            echo "::notice::Cache MISS ${name} (${hash})"
           fi
-        done
-        if [ "$miss" = "false" ]; then
-          for img in $IMAGES; do
-            docker tag \
-              "ghcr.io/openc3/${img}-buildcache:${CACHE_TAG}" \
-              "docker.io/openc3inc/${img}:${TAG}"
-          done
-          echo "hit=true" >> "$GITHUB_OUTPUT"
-          echo "::notice::Build cache HIT - skipped openc3.sh build (${CACHE_TAG})"
-        else
-          echo "hit=false" >> "$GITHUB_OUTPUT"
-          echo "::notice::Build cache MISS - will run openc3.sh build (${CACHE_TAG})"
-        fi
+        done < "$RUNNER_TEMP/cosmos-images.env"
+        echo "::notice::Build cache: ${hits} hit, ${misses} miss"
 
-    - name: openc3.sh build
-      if: steps.pull.outputs.hit != 'true'
+    - name: Build missed images
       # script -q -e -c works around https://github.com/actions/runner/issues/241
       shell: 'script -q -e -c "bash {0}"'
       env:
         OPENC3_TAG: ${{ inputs.tag }}
-      run: ./openc3.sh build
+      # Misses are already in topological order (the hash step writes them
+      # that way). Pulled parents are tagged locally as openc3inc/${name}:${TAG},
+      # so a child-only miss resolves its FROM without rebuilding the parent.
+      run: |
+        set -e
+        if [ ! -s "$RUNNER_TEMP/cosmos-misses.txt" ]; then
+          echo "::notice::All images cached - skipping build"
+          exit 0
+        fi
+        ./scripts/linux/openc3_setup.sh
+        umask 0022
+        chmod -R +r .
+        while read -r name; do
+          [ -z "$name" ] && continue
+          echo "::group::docker compose build ${name}"
+          docker compose -f compose.yaml -f compose-build.yaml build "$name"
+          echo "::endgroup::"
+        done < "$RUNNER_TEMP/cosmos-misses.txt"
 
-    - name: Push to GHCR cache
-      if: steps.pull.outputs.hit != 'true'
+    - name: Push built images to GHCR cache
       shell: bash
       env:
-        IMAGES: openc3-ruby openc3-base openc3-node openc3-buckets openc3-tsdb openc3-redis openc3-cosmos-cmd-tlm-api openc3-cosmos-script-runner-api openc3-operator openc3-traefik openc3-cosmos-init
-        CACHE_TAG: cache-${{ steps.hash.outputs.hash }}
         TAG: ${{ inputs.tag }}
       # Best-effort: a push failure (e.g. fork PR with no packages:write) is
-      # logged but does not fail the build for this run.
+      # logged but does not fail the run.
       run: |
         set +e
-        for img in $IMAGES; do
-          docker tag \
-            "docker.io/openc3inc/${img}:${TAG}" \
-            "ghcr.io/openc3/${img}-buildcache:${CACHE_TAG}"
-          if ! docker push "ghcr.io/openc3/${img}-buildcache:${CACHE_TAG}"; then
-            echo "::warning::Push failed for ${img}-buildcache:${CACHE_TAG}"
+        if [ ! -s "$RUNNER_TEMP/cosmos-misses.txt" ]; then
+          echo "::notice::No images to push (all cached)"
+          exit 0
+        fi
+        declare -A H
+        while IFS='=' read -r name hash; do
+          [ -z "$name" ] && continue
+          H[$name]=$hash
+        done < "$RUNNER_TEMP/cosmos-images.env"
+
+        while read -r name; do
+          [ -z "$name" ] && continue
+          dst="ghcr.io/openc3/${name}-buildcache:cache-${H[$name]}"
+          docker tag "docker.io/openc3inc/${name}:${TAG}" "$dst"
+          if ! docker push "$dst"; then
+            echo "::warning::Push failed for ${dst}"
           fi
-        done
+        done < "$RUNNER_TEMP/cosmos-misses.txt"

--- a/.github/actions/build-cosmos/action.yml
+++ b/.github/actions/build-cosmos/action.yml
@@ -1,0 +1,107 @@
+name: Build COSMOS
+description: |
+  Build all COSMOS Docker images, with GHCR-backed caching.
+
+  On cache hit (image-input hash matches a previously-pushed cache), pulls the
+  11 prebuilt images from ghcr.io/openc3/openc3-{name}-buildcache:cache-<hash>
+  and retags them as docker.io/openc3inc/openc3-{name}:<tag>. On cache miss
+  (or first push of the input-hash), runs `./openc3.sh build` and pushes the
+  resulting images to GHCR for future runs.
+
+  This is the "build once, pull elsewhere" pattern. Local developer builds
+  are unaffected — they continue to use `./openc3.sh build` directly.
+
+  The cleanup workflow at .github/workflows/cleanup-ghcr.yml prunes old cache
+  entries nightly so the *-buildcache packages don't accumulate.
+
+inputs:
+  tag:
+    description: OPENC3_TAG to apply to the resulting docker.io/openc3inc/* tags.
+    required: false
+    default: latest
+
+runs:
+  using: composite
+  steps:
+    - name: Compute image-input hash
+      id: hash
+      shell: bash
+      # Hash everything that affects image content. Using `git ls-tree` (vs
+      # hashFiles) keeps the input list maintainable and ignores untracked
+      # build artifacts. The 12-char prefix is plenty for collision avoidance
+      # given our scale.
+      run: |
+        HASH=$(git ls-tree -r HEAD \
+          openc3-ruby openc3 openc3-node openc3-buckets openc3-tsdb openc3-redis \
+          openc3-cosmos-cmd-tlm-api openc3-cosmos-script-runner-api openc3-operator \
+          openc3-traefik openc3-cosmos-init docs.openc3.com \
+          compose.yaml compose-build.yaml .env \
+          | sha256sum | cut -c1-12)
+        echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+        echo "Image-input hash: $HASH"
+
+    - name: Login to GHCR
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        echo "$GH_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin \
+          || echo "::warning::GHCR login failed (likely a fork PR); cache pull/push will be skipped"
+
+    - name: Try GHCR cache pull
+      id: pull
+      shell: bash
+      env:
+        IMAGES: openc3-ruby openc3-base openc3-node openc3-buckets openc3-tsdb openc3-redis openc3-cosmos-cmd-tlm-api openc3-cosmos-script-runner-api openc3-operator openc3-traefik openc3-cosmos-init
+        CACHE_TAG: cache-${{ steps.hash.outputs.hash }}
+        TAG: ${{ inputs.tag }}
+      run: |
+        set -e
+        miss=false
+        for img in $IMAGES; do
+          if ! docker pull "ghcr.io/openc3/${img}-buildcache:${CACHE_TAG}"; then
+            echo "::notice::Cache miss for ${img}:${CACHE_TAG}"
+            miss=true
+            break
+          fi
+        done
+        if [ "$miss" = "false" ]; then
+          for img in $IMAGES; do
+            docker tag \
+              "ghcr.io/openc3/${img}-buildcache:${CACHE_TAG}" \
+              "docker.io/openc3inc/${img}:${TAG}"
+          done
+          echo "hit=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::Build cache HIT - skipped openc3.sh build (${CACHE_TAG})"
+        else
+          echo "hit=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::Build cache MISS - will run openc3.sh build (${CACHE_TAG})"
+        fi
+
+    - name: openc3.sh build
+      if: steps.pull.outputs.hit != 'true'
+      # script -q -e -c works around https://github.com/actions/runner/issues/241
+      shell: 'script -q -e -c "bash {0}"'
+      env:
+        OPENC3_TAG: ${{ inputs.tag }}
+      run: ./openc3.sh build
+
+    - name: Push to GHCR cache
+      if: steps.pull.outputs.hit != 'true'
+      shell: bash
+      env:
+        IMAGES: openc3-ruby openc3-base openc3-node openc3-buckets openc3-tsdb openc3-redis openc3-cosmos-cmd-tlm-api openc3-cosmos-script-runner-api openc3-operator openc3-traefik openc3-cosmos-init
+        CACHE_TAG: cache-${{ steps.hash.outputs.hash }}
+        TAG: ${{ inputs.tag }}
+      # Best-effort: a push failure (e.g. fork PR with no packages:write) is
+      # logged but does not fail the build for this run.
+      run: |
+        set +e
+        for img in $IMAGES; do
+          docker tag \
+            "docker.io/openc3inc/${img}:${TAG}" \
+            "ghcr.io/openc3/${img}-buildcache:${CACHE_TAG}"
+          if ! docker push "ghcr.io/openc3/${img}-buildcache:${CACHE_TAG}"; then
+            echo "::warning::Push failed for ${img}-buildcache:${CACHE_TAG}"
+          fi
+        done

--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write # required to push the GHCR build cache
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -46,12 +47,9 @@ jobs:
           ruby-version: 3.4
           bundler-cache: false # runs 'bundle install' and caches installed gems automatically
           working-directory: openc3
-      - name: openc3.sh build
-        # This `shell` line is required to get around a known issue: https://github.com/actions/runner/issues/241#issuecomment-745902718
-        shell: 'script -q -e -c "bash {0}"'
-        run: ./openc3.sh build
-        env:
-          OPENC3_TAG: ${{ github.sha }}
+      - uses: ./.github/actions/build-cosmos
+        with:
+          tag: ${{ github.sha }}
       - name: ClamAV setup and update definitions
         # This `shell` line is required to get around a known issue: https://github.com/actions/runner/issues/241#issuecomment-745902718
         shell: 'script -q -e -c "bash {0}"'

--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -1,0 +1,31 @@
+name: Cleanup GHCR Build Cache
+
+# Prunes the *-buildcache GHCR packages used by .github/actions/build-cosmos.
+# Keeps the most recent N tagged versions per package and deletes untagged
+# manifests left behind when cache tags are overwritten.
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # daily at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune *-buildcache packages
+        # https://github.com/dataaxiom/ghcr-cleanup-action
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
+        with:
+          owner: openc3
+          # Wildcards enabled by expand-packages — matches every cache package
+          # created by .github/actions/build-cosmos in one shot.
+          packages: openc3-*-buildcache
+          expand-packages: true
+          # Keep enough headroom for in-flight PRs while preventing the cache
+          # backlog from growing unbounded.
+          keep-n-tagged: 50
+          delete-untagged: true

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write # required to push the GHCR build cache
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -44,10 +45,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: openc3.sh build
-        # This `shell` line is required to get around a known issue: https://github.com/actions/runner/issues/241#issuecomment-745902718
-        shell: 'script -q -e -c "bash {0}"'
-        run: ./openc3.sh build
+      - uses: ./.github/actions/build-cosmos
       - name: openc3.sh run
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/playwright-firefox-nightly.yml
+++ b/.github/workflows/playwright-firefox-nightly.yml
@@ -32,6 +32,7 @@ jobs:
       fail-fast: false
     permissions:
       contents: read
+      packages: write # required to push the GHCR build cache
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -42,10 +43,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - name: openc3.sh build
-        # This `shell` line is required to get around a known issue: https://github.com/actions/runner/issues/241#issuecomment-745902718
-        shell: 'script -q -e -c "bash {0}"'
-        run: ./openc3.sh build
+      - uses: ./.github/actions/build-cosmos
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:
           version: 10

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -39,6 +39,7 @@ jobs:
       fail-fast: false
     permissions:
       contents: read
+      packages: write # required to push the GHCR build cache
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -49,10 +50,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - name: openc3.sh build
-        # This `shell` line is required to get around a known issue: https://github.com/actions/runner/issues/241#issuecomment-745902718
-        shell: 'script -q -e -c "bash {0}"'
-        run: ./openc3.sh build
+      - uses: ./.github/actions/build-cosmos
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:
           version: 10

--- a/.github/workflows/tool.yml
+++ b/.github/workflows/tool.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write # required to push the GHCR build cache
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -51,10 +52,7 @@ jobs:
         uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:
           version: 10
-      - name: openc3.sh build
-        # This `shell` line is required to get around a known issue: https://github.com/actions/runner/issues/241#issuecomment-745902718
-        shell: 'script -q -e -c "bash {0}"'
-        run: ./openc3.sh build
+      - uses: ./.github/actions/build-cosmos
       - name: openc3.sh run
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -35,15 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write # required to push the GHCR build cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: openc3.sh build
-        id: build
-        # This `shell` line is required to get around a known issue: https://github.com/actions/runner/issues/241#issuecomment-745902718
-        shell: 'script -q -e -c "bash {0}"'
-        run: ./openc3.sh build
-        env:
-          OPENC3_TAG: ${{ github.sha }}
+      - id: build
+        uses: ./.github/actions/build-cosmos
+        with:
+          tag: ${{ github.sha }}
       - name: Manual Trivy Setup
         uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514
         with:


### PR DESCRIPTION
Replace per-workflow `openc3.sh build` with a composite action that keys on a content hash of all image-input directories, pulls prebuilt images from ghcr.io/openc3/openc3-{name}-buildcache:cache-<hash> on hit, and runs the build + pushes to GHCR on miss.

For typical PR pushes that don't touch openc3-ruby/openc3/openc3-node or any other build context, the 5 build-using workflows (playwright, playwright-firefox-nightly, cli, clamav, trivy, tool) skip the build entirely and just `docker pull` from GHCR. First push of an image- input change still has the workflows building in parallel — they'll all push to the same cache tag, last writer wins, no harm.

Cache packages live at `*-buildcache` GHCR packages so the public `openc3-{name}` package version lists stay clean. The new cleanup-ghcr.yml workflow runs nightly via dataaxiom/ghcr-cleanup-action to keep the 50 newest tagged versions per cache package and delete untagged manifests, capping growth.

Local builds are unaffected. ./openc3.sh build, all Dockerfiles, compose-build.yaml — none of those changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)