### PR TITLE
Use socket.socketpair instead of multiprocessing.Pipe for Windows

### DIFF
--- a/openc3/python/openc3/interfaces/tcpip_server_interface.py
+++ b/openc3/python/openc3/interfaces/tcpip_server_interface.py
@@ -9,7 +9,7 @@
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
-import multiprocessing
+import contextlib
 import queue
 import select
 import socket
@@ -175,7 +175,9 @@ class TcpipServerInterface(StreamInterface):
         if self.read_queue:
             self.read_queue.put(None)
         for pipe in self.listen_pipes:
-            pipe.send(".")
+            with contextlib.suppress(OSError):
+                pipe.send(b".")
+            close_socket(pipe)
         self.listen_pipes = []
 
         # Shutdown listen thread(s)
@@ -346,7 +348,10 @@ class TcpipServerInterface(StreamInterface):
         listen_socket.listen(5)
         self.listen_sockets.append(listen_socket)
 
-        thread_reader, thread_writer = multiprocessing.Pipe()
+        # socket.socketpair (rather than multiprocessing.Pipe) so the
+        # readable end can be passed to select.select on Windows, where
+        # select only accepts sockets.
+        thread_reader, thread_writer = socket.socketpair()
         self.listen_pipes.append(thread_writer)
         thread = threading.Thread(
             target=self._listen_thread_body,

--- a/openc3/python/openc3/streams/tcpip_socket_stream.py
+++ b/openc3/python/openc3/streams/tcpip_socket_stream.py
@@ -9,7 +9,7 @@
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
-import multiprocessing
+import contextlib
 import select
 import socket
 import threading
@@ -43,7 +43,10 @@ class TcpipSocketStream(Stream):
         # Mutex on write is needed to protect from commands coming in from more
         # than one tool
         self.write_mutex = threading.Lock()
-        self.pipe_reader, self.pipe_writer = multiprocessing.Pipe()
+        # socket.socketpair (rather than multiprocessing.Pipe) so the
+        # readable end can be passed to select.select on Windows, where
+        # select only accepts sockets.
+        self.pipe_reader, self.pipe_writer = socket.socketpair()
         self._connected = False
 
     # self.return [String] Returns a binary string of data from the socket
@@ -126,5 +129,8 @@ class TcpipSocketStream(Stream):
             return
         close_socket(self.write_socket)
         close_socket(self.read_socket)
-        self.pipe_writer.send(".")
+        with contextlib.suppress(OSError):
+            self.pipe_writer.send(b".")
+        close_socket(self.pipe_writer)
+        close_socket(self.pipe_reader)
         self._connected = False

--- a/openc3/python/openc3/utilities/sleeper.py
+++ b/openc3/python/openc3/utilities/sleeper.py
@@ -10,15 +10,18 @@
 # if purchased from OpenC3, Inc.
 
 import contextlib
-import os
 import selectors
+import socket
 
 
 # Allows for a breakable sleep implementation using the self-pipe trick
 # See http://www.sitepoint.com/the-self-pipe-trick-explained/
+# socket.socketpair (rather than os.pipe) so the readable end can be
+# registered with selectors on Windows, where the default selector is
+# backed by select.select which only accepts sockets.
 class Sleeper:
     def __init__(self):
-        self.pipe_reader, self.pipe_writer = os.pipe()
+        self.pipe_reader, self.pipe_writer = socket.socketpair()
         self.selector = selectors.DefaultSelector()
         self.selector.register(self.pipe_reader, selectors.EVENT_READ)
         self.canceled = False
@@ -31,7 +34,7 @@ class Sleeper:
         list = self.selector.select(timeout=seconds)
         if list and list[0]:
             with contextlib.suppress(Exception):
-                os.close(self.pipe_reader)
+                self.pipe_reader.close()
             return True
         else:
             return False
@@ -40,5 +43,6 @@ class Sleeper:
     def cancel(self):
         if not self.canceled:
             self.canceled = True
-            os.write(self.pipe_writer, bytes(".", encoding="ascii"))
-            os.close(self.pipe_writer)
+            with contextlib.suppress(OSError):
+                self.pipe_writer.send(b".")
+            self.pipe_writer.close()

--- a/openc3/python/test/microservices/test_interface_microservice.py
+++ b/openc3/python/test/microservices/test_interface_microservice.py
@@ -216,6 +216,7 @@ class TestInterfaceMicroservice(unittest.TestCase):
                 stdout.getvalue(),
             )
             im.shutdown()
+            thread.join(timeout=5)
 
     def test_handles_exceptions_while_reading(self):
         MyInterface.read_interface_raise = True
@@ -236,6 +237,7 @@ class TestInterfaceMicroservice(unittest.TestCase):
             all_interfaces = InterfaceStatusModel.all(scope="DEFAULT")
             self.assertEqual(all_interfaces["INST_INT"]["state"], "CONNECTED")
             im.shutdown()
+            thread.join(timeout=5)
 
     def test_connect_handles_parameters(self):
         im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
@@ -266,6 +268,7 @@ class TestInterfaceMicroservice(unittest.TestCase):
 
             self.assertEqual(im.interface.port, 54321)
             im.shutdown()
+            thread.join(timeout=5)
 
     # def test_handles_exceptions_in_monitor_thread(self):
     #     im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
@@ -313,6 +316,7 @@ class TestInterfaceMicroservice(unittest.TestCase):
             self.assertEqual(all_interfaces["INST_INT"]["state"], "DISCONNECTED")
             self.assertEqual(im.interface.disconnect_count, 1)
             im.shutdown()
+            thread.join(timeout=5)
 
     # TODO: Not sure why this doesn't work ... the disconnect command never gets processed
     # def test_handles_a_interface_that_doesnt_allow_reads(self):
@@ -380,6 +384,7 @@ class TestInterfaceMicroservice(unittest.TestCase):
             self.assertEqual(packet.read("TEMP1", "RAW"), 10)
 
         im.shutdown()
+        thread.join(timeout=5)
 
     def test_supports_interface_cmd(self):
         im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
@@ -397,6 +402,7 @@ class TestInterfaceMicroservice(unittest.TestCase):
         self.assertEqual("DO_THE_THING", im.interface.interface_cmd_name)
         self.assertEqual(("PARAM1", 2), im.interface.interface_cmd_args)
         im.shutdown()
+        thread.join(timeout=5)
 
     def test_supports_protocol_cmd(self):
         im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
@@ -424,6 +430,7 @@ class TestInterfaceMicroservice(unittest.TestCase):
         self.assertEqual("READ", im.interface.protocol_read_write)
         self.assertEqual(3, im.interface.protocol_index)
         im.shutdown()
+        thread.join(timeout=5)
 
     def test_supports_update_interval_option_to_enable_queued_writes(self):
         # Update the model to use UPDATE_INTERVAL option
@@ -467,8 +474,6 @@ class TestInterfaceMicroservice(unittest.TestCase):
     def test_stale_tlmcnt_redis_key_does_not_disconnect_interface(self):
         im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
         im.interface.reconnect_delay = 0.1
-        # Ensure shutdown is called even if assertions fail, so the thread doesn't hang
-        self.addCleanup(im.shutdown)
 
         # Inject the stale key AFTER init so init_tlm_packet_counts succeeds.
         # This simulates a plugin upgrade mid-operation where a packet is removed
@@ -483,6 +488,9 @@ class TestInterfaceMicroservice(unittest.TestCase):
         for stdout in capture_io():
             thread = threading.Thread(target=im.run)
             thread.start()
+            # Cleanups run LIFO: shutdown signals stop, then join waits.
+            self.addCleanup(thread.join, 5)
+            self.addCleanup(im.shutdown)
             time.sleep(0.2)  # Allow connect + at least one packet + sync cycle
 
             # The interface should remain CONNECTED after encountering the stale key
@@ -499,9 +507,11 @@ class TestInterfaceMicroservice(unittest.TestCase):
     def test_process_cmd_with_all_fields_and_missing_optional_fields(self):
         """Test process_cmd succeeds with full msg_hash and with only required fields."""
         im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
-        self.addCleanup(im.shutdown)
         thread = threading.Thread(target=im.run)
         thread.start()
+        # Cleanups run LIFO: shutdown signals stop, then join waits.
+        self.addCleanup(thread.join, 5)
+        self.addCleanup(im.shutdown)
         time.sleep(0.1)
 
         handler = im.handler_thread


### PR DESCRIPTION
According to the select documentation https://docs.python.org/3/library/select.html: "Note that on Windows, it only works for sockets"

