### PR TITLE
Handle socket.MSG_DONTWAIT on Windows

### DIFF
--- a/openc3/python/openc3/interfaces/tcpip_server_interface.py
+++ b/openc3/python/openc3/interfaces/tcpip_server_interface.py
@@ -23,6 +23,10 @@ from openc3.top_level import close_socket, kill_thread
 from openc3.utilities.logger import Logger
 
 
+# socket.MSG_DONTWAIT is Unix-only; on Windows we rely on setblocking(False).
+_MSG_DONTWAIT = getattr(socket, "MSG_DONTWAIT", 0)
+
+
 # Data class which stores the interface and associated information
 class InterfaceInfo:
     # attr_reader :interface, :hostname, :host_ip, :port
@@ -383,6 +387,7 @@ class TcpipServerInterface(StreamInterface):
 
             # Configure TCP_NODELAY option
             client_socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            client_socket.setblocking(False)
 
             # Accept Connection
             write_socket = None
@@ -549,7 +554,7 @@ class TcpipServerInterface(StreamInterface):
                 for interface_info in self.write_interface_infos:
                     if self.write_port != self.read_port:
                         # Socket should return EWOULDBLOCK if it is still cleanly connected
-                        interface_info.interface.stream.write_socket.recv(10, socket.MSG_DONTWAIT)
+                        interface_info.interface.stream.write_socket.recv(10, _MSG_DONTWAIT)
                     elif interface_info.interface.stream.write_socket.fileno() != -1:
                         # Let read thread detect disconnect
                         continue

--- a/openc3/python/openc3/io/udp_sockets.py
+++ b/openc3/python/openc3/io/udp_sockets.py
@@ -14,6 +14,10 @@ import select
 import socket
 
 
+# socket.MSG_DONTWAIT is Unix-only; on Windows we rely on setblocking(False).
+_MSG_DONTWAIT = getattr(socket, "MSG_DONTWAIT", 0)
+
+
 class UdpReadWriteSocket:
     # @param bind_port [Integer[ Port to write data out from and receive data on (0 = randomly assigned)
     # @param bind_address [String] Local address to bind to (0.0.0.0 = All local addresses)
@@ -35,6 +39,7 @@ class UdpReadWriteSocket:
         write_multicast=True,
     ):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.socket.setblocking(False)
 
         # Basic setup to reuse address
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -96,7 +101,7 @@ class UdpReadWriteSocket:
         data = None
         while True:
             try:
-                data, _ = self.socket.recvfrom(65536, socket.MSG_DONTWAIT)
+                data, _ = self.socket.recvfrom(65536, _MSG_DONTWAIT)
             except OSError as e:
                 if e.args[0] == socket.EAGAIN or e.args[0] == socket.EWOULDBLOCK:
                     result = select.select([self.socket], [], [], read_timeout)

--- a/openc3/python/openc3/streams/tcpip_socket_stream.py
+++ b/openc3/python/openc3/streams/tcpip_socket_stream.py
@@ -20,6 +20,10 @@ from openc3.top_level import close_socket
 from openc3.utilities.logger import Logger
 
 
+# socket.MSG_DONTWAIT is Unix-only; on Windows we rely on setblocking(False).
+_MSG_DONTWAIT = getattr(socket, "MSG_DONTWAIT", 0)
+
+
 class TcpipSocketStream(Stream):
     # self.param write_socket [Socket] Socket to write
     # self.param read_socket [Socket] Socket to read
@@ -58,7 +62,7 @@ class TcpipSocketStream(Stream):
         # No read mutex is needed because reads happen serially
         while True:  # Loop until we get some data
             try:
-                data = self.read_socket.recv(65535, socket.MSG_DONTWAIT)
+                data = self.read_socket.recv(65535, _MSG_DONTWAIT)
             # Non-blocking sockets return an errno EAGAIN or EWOULDBLOCK
             # if there is no data available
             except OSError as error:
@@ -92,7 +96,7 @@ class TcpipSocketStream(Stream):
 
             while True:
                 try:
-                    bytes_sent = self.write_socket.send(data_to_send, socket.MSG_DONTWAIT)
+                    bytes_sent = self.write_socket.send(data_to_send, _MSG_DONTWAIT)
                 # Non-blocking sockets return an errno EAGAIN or EWOULDBLOCK
                 # if the write would block
                 except OSError as error:


### PR DESCRIPTION
Prevents the following type errors when running a Python bridge on Windows:

```
  File cosmos\\openc3\\python\\openc3\\interfaces\\tcpip_server_interface.py\", line 431, in _start_read_thread
    self._read_thread_body(interface_info.interface)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File cosmos\\openc3\\python\\openc3\\interfaces\\tcpip_server_interface.py\", line 525, in _read_thread_body
    packet = interface.read()
  File cosmos\\openc3\\python\\openc3\\interfaces\\interface.py\", line 218, in read
    raise error
  File cosmos\\openc3\\python\\openc3\\interfaces\\interface.py\", line 170, in read
    data, extra = self.read_interface()
                  ~~~~~~~~~~~~~~~~~~~^^
  File cosmos\\openc3\\python\\openc3\\interfaces\\stream_interface.py\", line 53, in read_interface
    data = self.stream.read()
  File cosmos\\openc3\\python\\openc3\\streams\\tcpip_socket_stream.py\", line 61, in read
    data = self.read_socket.recv(65535, socket.MSG_DONTWAIT)
                                        ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'socket' has no attribute 'MSG_DONTWAIT'. Did you mean: 'MSG_DONTROUTE'?
```