### PR TITLE
Support for consistent command queue structure

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/controllers/queues_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/queues_controller.rb
@@ -134,12 +134,17 @@ class QueuesController < ApplicationController
   end
 
   def insert_command
+    target_name = params[:target_name]
+    cmd_name = params[:cmd_name]
     command = params[:command]
-    if command.nil?
-      render json: { status: 'error', message: 'command is required' }, status: :bad_request
+    if target_name && cmd_name
+      packet_name = cmd_name
+    elsif command
+      target_name, packet_name = command.strip.split(' ')
+    else
+      render json: { status: 'error', message: 'target_name/cmd_name or command is required' }, status: :bad_request
       return
     end
-    target_name, packet_name = command.strip.split(' ')
     return unless authorization('cmd', target_name: target_name, packet_name: packet_name)
     begin
       model = @model_class.get_model(name: params[:name], scope: params[:scope])
@@ -152,7 +157,14 @@ class QueuesController < ApplicationController
         id = params[:id].to_f
       end
       # If params[:id] is not given this will be nil which means insert at the end
-      command_data = { username: username(), value: command, timestamp: Time.now.to_nsec_from_epoch }
+      command_data = { username: username(), timestamp: Time.now.to_nsec_from_epoch }
+      if params[:target_name] && params[:cmd_name]
+        command_data[:target_name] = params[:target_name]
+        command_data[:cmd_name] = params[:cmd_name]
+        command_data[:cmd_params] = JSON.generate(params[:cmd_params].as_json, allow_nan: true) unless params[:cmd_params].nil?
+      else
+        command_data[:value] = command
+      end
       command_data[:validate] = params[:validate] unless params[:validate].nil?
       command_data[:timeout] = params[:timeout] unless params[:timeout].nil?
       model.insert_command(id, command_data)
@@ -185,12 +197,17 @@ class QueuesController < ApplicationController
   end
 
   def update_command
+    target_name = params[:target_name]
+    cmd_name = params[:cmd_name]
     command = params[:command]
-    if command.nil?
-      render json: { status: 'error', message: 'command is required' }, status: :bad_request
+    if target_name && cmd_name
+      packet_name = cmd_name
+    elsif command
+      target_name, packet_name = command.strip.split(' ')
+    else
+      render json: { status: 'error', message: 'target_name/cmd_name or command is required' }, status: :bad_request
       return
     end
-    target_name, packet_name = command.strip.split(' ')
     return unless authorization('cmd', target_name: target_name, packet_name: packet_name)
     begin
       model = @model_class.get_model(name: params[:name], scope: params[:scope])
@@ -206,7 +223,11 @@ class QueuesController < ApplicationController
       # validate should be true or false, default to true if not given
       validate = params[:validate].nil? ? true : params[:validate]
       # timeout can be nil which means use system default timeout
-      model.update_command(id: id, username: username(), command: command, validate: validate, timeout: params[:timeout])
+      if params[:target_name] && params[:cmd_name]
+        model.update_command(id: id, username: username(), target_name: params[:target_name], cmd_name: params[:cmd_name], cmd_params: params[:cmd_params], validate: validate, timeout: params[:timeout])
+      else
+        model.update_command(id: id, username: username(), command: command, validate: validate, timeout: params[:timeout])
+      end
       render json: { status: 'success', message: 'Command updated' }
     rescue OpenC3::QueueError => e
       log_error(e)

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/queues_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/queues_controller.rb
@@ -152,22 +152,15 @@ class QueuesController < ApplicationController
         render json: { status: 'error', message: NOT_FOUND }, status: :not_found
         return
       end
-      id = nil
-      if params[:id]
-        id = params[:id].to_f
-      end
-      # If params[:id] is not given this will be nil which means insert at the end
-      command_data = { username: username(), timestamp: Time.now.to_nsec_from_epoch }
-      if params[:target_name] && params[:cmd_name]
-        command_data[:target_name] = params[:target_name]
-        command_data[:cmd_name] = params[:cmd_name]
-        command_data[:cmd_params] = JSON.generate(params[:cmd_params].as_json, allow_nan: true) unless params[:cmd_params].nil?
+      id = params[:id]&.to_f
+      # If id is nil this means insert at the end
+      if target_name && cmd_name
+        model.insert_command(id: id, username: username(), target_name: target_name, cmd_name: cmd_name,
+                             cmd_params: params[:cmd_params], validate: params[:validate], timeout: params[:timeout])
       else
-        command_data[:value] = command
+        model.insert_command(id: id, username: username(), command: command,
+                             validate: params[:validate], timeout: params[:timeout])
       end
-      command_data[:validate] = params[:validate] unless params[:validate].nil?
-      command_data[:timeout] = params[:timeout] unless params[:timeout].nil?
-      model.insert_command(id, command_data)
       render json: { status: 'success', message: 'Command added to queue' }
     rescue StandardError => e
       log_error(e)
@@ -223,8 +216,9 @@ class QueuesController < ApplicationController
       # validate should be true or false, default to true if not given
       validate = params[:validate].nil? ? true : params[:validate]
       # timeout can be nil which means use system default timeout
-      if params[:target_name] && params[:cmd_name]
-        model.update_command(id: id, username: username(), target_name: params[:target_name], cmd_name: params[:cmd_name], cmd_params: params[:cmd_params], validate: validate, timeout: params[:timeout])
+      if target_name && cmd_name
+        model.update_command(id: id, username: username(), target_name: target_name, cmd_name: cmd_name,
+                             cmd_params: params[:cmd_params], validate: validate, timeout: params[:timeout])
       else
         model.update_command(id: id, username: username(), command: command, validate: validate, timeout: params[:timeout])
       end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/queues_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/queues_controller.rb
@@ -13,6 +13,7 @@
 
 require 'openc3/models/queue_model'
 require 'openc3/models/offline_access_model'
+require 'openc3/topics/decom_interface_topic'
 require 'openc3/utilities/authentication'
 require 'openc3/api/api'
 
@@ -152,6 +153,16 @@ class QueuesController < ApplicationController
         render json: { status: 'error', message: NOT_FOUND }, status: :not_found
         return
       end
+      if target_name && cmd_name
+        cmd_params = params[:cmd_params]
+        cmd_params = cmd_params.to_unsafe_h if cmd_params.respond_to?(:to_unsafe_h)
+        begin
+          OpenC3::DecomInterfaceTopic.build_cmd(target_name, cmd_name, cmd_params || {}, true, false, scope: params[:scope])
+        rescue StandardError => e
+          render json: { status: 'error', message: e.message, type: e.class.to_s }, status: :bad_request
+          return
+        end
+      end
       id = params[:id]&.to_f
       # If id is nil this means insert at the end
       if target_name && cmd_name
@@ -212,6 +223,16 @@ class QueuesController < ApplicationController
       if id.nil?
         render json: { status: 'error', message: 'id is required' }, status: :bad_request
         return
+      end
+      if target_name && cmd_name
+        cmd_params = params[:cmd_params]
+        cmd_params = cmd_params.to_unsafe_h if cmd_params.respond_to?(:to_unsafe_h)
+        begin
+          OpenC3::DecomInterfaceTopic.build_cmd(target_name, cmd_name, cmd_params || {}, true, false, scope: params[:scope])
+        rescue StandardError => e
+          render json: { status: 'error', message: e.message, type: e.class.to_s }, status: :bad_request
+          return
+        end
       end
       # validate should be true or false, default to true if not given
       validate = params[:validate].nil? ? true : params[:validate]

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/queues_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/queues_controller_spec.rb
@@ -277,7 +277,13 @@ RSpec.describe QueuesController, type: :controller do
       json = JSON.parse(response.body, allow_nan: true, create_additions: true)
       expect(json["status"]).to eql("success")
       expect(json["message"]).to eql("Command added to queue")
-      expect(queue_model).to have_received(:insert_command).with(nil, { username: "anonymous", value: "TEST COMMAND", timestamp: anything })
+      expect(queue_model).to have_received(:insert_command).with(
+        id: nil,
+        username: "anonymous",
+        command: "TEST COMMAND",
+        validate: nil,
+        timeout: nil
+      )
     end
 
     it "inserts a command at id and returns status code 200" do
@@ -291,7 +297,13 @@ RSpec.describe QueuesController, type: :controller do
       json = JSON.parse(response.body, allow_nan: true, create_additions: true)
       expect(json["status"]).to eql("success")
       expect(json["message"]).to eql("Command added to queue")
-      expect(queue_model).to have_received(:insert_command).with(id.to_f, { username: "anonymous", value: "TEST COMMAND", timestamp: anything })
+      expect(queue_model).to have_received(:insert_command).with(
+        id: id.to_f,
+        username: "anonymous",
+        command: "TEST COMMAND",
+        validate: nil,
+        timeout: nil
+      )
     end
 
     it "returns 404 when the queue is not found" do

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/queues_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/queues_controller_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe QueuesController, type: :controller do
       expect(response).to have_http_status(400)
       json = JSON.parse(response.body, allow_nan: true, create_additions: true)
       expect(json["status"]).to eql("error")
-      expect(json["message"]).to eql("command is required")
+      expect(json["message"]).to eql("target_name/cmd_name or command is required")
     end
 
     it "returns 500 when an unexpected error occurs" do
@@ -451,7 +451,7 @@ RSpec.describe QueuesController, type: :controller do
       expect(response).to have_http_status(400)
       json = JSON.parse(response.body, allow_nan: true, create_additions: true)
       expect(json["status"]).to eql("error")
-      expect(json["message"]).to eql("command is required")
+      expect(json["message"]).to eql("target_name/cmd_name or command is required")
     end
 
     it "returns 400 when id is missing" do

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
@@ -410,72 +410,6 @@ export default {
     this.editor.container.remove()
   },
   methods: {
-    convertToValue(param) {
-      if (param.val !== undefined && param.states && !this.cmdRaw) {
-        const stateName = Object.keys(param.states).find(
-          (state) => param.states[state].value === param.val,
-        )
-        if (stateName !== undefined) {
-          return stateName
-        }
-        // No matching state found (manually entered value), fall through
-        // to parse the raw value below
-      }
-      if (typeof param.val !== 'string') {
-        return param.val
-      }
-
-      let str = param.val
-      let quotesRemoved = this.removeQuotes(str)
-      if (str === quotesRemoved) {
-        let upcaseStr = str.toUpperCase()
-        if (
-          (param.type === 'STRING' || param.type === 'BLOCK') &&
-          upcaseStr.startsWith('0X')
-        ) {
-          let hexStr = upcaseStr.slice(2)
-          if (hexStr.length % 2 !== 0) {
-            hexStr = '0' + hexStr
-          }
-          let jstr = { json_class: 'String', raw: [] }
-          for (let i = 0; i < hexStr.length; i += 2) {
-            let nibble = hexStr.charAt(i) + hexStr.charAt(i + 1)
-            jstr.raw.push(Number.parseInt(nibble, 16))
-          }
-          return jstr
-        } else {
-          if (upcaseStr === 'INFINITY') {
-            return Infinity
-          } else if (upcaseStr === '-INFINITY') {
-            return -Infinity
-          } else if (upcaseStr === 'NAN') {
-            return NaN
-          } else if (this.isFloat(str)) {
-            return Number.parseFloat(str)
-          } else if (this.isInt(str)) {
-            // If this is a number that is too large for a JS number
-            // then we convert it to a BigInt which gets serialized in openc3Api.js
-            if (!Number.isSafeInteger(Number(str))) {
-              return BigInt(str)
-            } else {
-              return Number.parseInt(str)
-            }
-          } else if (this.isArray(str)) {
-            try {
-              return JSON.parse(str)
-            } catch {
-              this.status = `Invalid array parameter value: ${str}`
-              this.displayErrorDialog = true
-              return str
-            }
-          } else {
-            return str
-          }
-        }
-      } else {
-        return quotesRemoved
-      }
-    },
     commandChanged(event) {
       if (
         this.targetName !== event.targetName ||
@@ -556,7 +490,15 @@ export default {
     },
 
     buildCmd() {
-      this.sendCmd(this.targetName, this.commandName, this.createParamList())
+      let paramList
+      try {
+        paramList = this.createParamList()
+      } catch (e) {
+        this.status = e.message
+        this.displayErrorDialog = true
+        return
+      }
+      this.sendCmd(this.targetName, this.commandName, paramList)
     },
 
     // Note targetName can also be the entire command to send, e.g. "INST ABORT" or

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/cmdUtilities.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/cmdUtilities.js
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2025, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -61,6 +61,60 @@ export default {
         return str
       }
       return str.slice(1, -1)
+    },
+
+    convertToValue(param) {
+      if (param.val !== undefined && param.states && !this.cmdRaw) {
+        const stateName = Object.keys(param.states).find(
+          (state) => param.states[state].value === param.val,
+        )
+        if (stateName !== undefined) {
+          return stateName
+        }
+        // No matching state found (manually entered value), fall through
+        // to parse the raw value below
+      }
+      if (typeof param.val !== 'string') {
+        return param.val
+      }
+
+      let str = param.val
+      let quotesRemoved = this.removeQuotes(str)
+      if (str === quotesRemoved) {
+        let upcaseStr = str.toUpperCase()
+        if (
+          (param.type === 'STRING' || param.type === 'BLOCK') &&
+          upcaseStr.startsWith('0X')
+        ) {
+          let hexStr = upcaseStr.slice(2)
+          if (hexStr.length % 2 !== 0) {
+            hexStr = '0' + hexStr
+          }
+          let jstr = { json_class: 'String', raw: [] }
+          for (let i = 0; i < hexStr.length; i += 2) {
+            let nibble = hexStr.charAt(i) + hexStr.charAt(i + 1)
+            jstr.raw.push(Number.parseInt(nibble, 16))
+          }
+          return jstr
+        }
+        if (upcaseStr === 'INFINITY') return Infinity
+        if (upcaseStr === '-INFINITY') return -Infinity
+        if (upcaseStr === 'NAN') return NaN
+        if (this.isFloat(str)) return Number.parseFloat(str)
+        if (this.isInt(str)) {
+          if (!Number.isSafeInteger(Number(str))) return BigInt(str)
+          return Number.parseInt(str)
+        }
+        if (this.isArray(str)) {
+          try {
+            return JSON.parse(str)
+          } catch {
+            throw new Error(`Invalid array parameter value: ${str}`)
+          }
+        }
+        return str
+      }
+      return quotesRemoved
     },
 
     convertToString(value) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/cmdUtilities.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/cmdUtilities.js
@@ -97,9 +97,9 @@ export default {
           }
           return jstr
         }
-        if (upcaseStr === 'INFINITY') return Infinity
-        if (upcaseStr === '-INFINITY') return -Infinity
-        if (upcaseStr === 'NAN') return NaN
+        if (upcaseStr === 'INFINITY') return Number.POSITIVE_INFINITY
+        if (upcaseStr === '-INFINITY') return Number.NEGATIVE_INFINITY
+        if (upcaseStr === 'NAN') return Number.NaN
         if (this.isFloat(str)) return Number.parseFloat(str)
         if (this.isInt(str)) {
           if (!Number.isSafeInteger(Number(str))) return BigInt(str)

--- a/openc3/lib/openc3/models/queue_model.rb
+++ b/openc3/lib/openc3/models/queue_model.rb
@@ -44,34 +44,37 @@ module OpenC3
       model = get_model(name: name, scope: scope)
       raise QueueError, "Queue '#{name}' not found in scope '#{scope}'" unless model
 
-      if model.state != 'DISABLE'
-        result = Store.zrevrange("#{scope}:#{name}", 0, 0, with_scores: true)
-        if result.empty?
-          id = 1.0
-        else
-          id = result[0][1].to_f + 1
-        end
-
-        # Build command data with support for both formats
-        command_data = { username: username, timestamp: Time.now.to_nsec_from_epoch, validate: validate, timeout: timeout }
-        if target_name && cmd_name
-          # New format: store target_name, cmd_name, and cmd_params separately
-          command_data[:target_name] = target_name
-          command_data[:cmd_name] = cmd_name
-          command_data[:cmd_params] = JSON.generate(cmd_params.as_json, allow_nan: true) if cmd_params
-        elsif command
-          # Legacy format: store command string for backwards compatibility
-          command_data[:value] = command
-        else
-          raise QueueError, "Must provide either command string or target_name/cmd_name parameters"
-        end
-
-        Store.zadd("#{scope}:#{name}", id, command_data.to_json)
-        model.notify(kind: 'command')
-      else
+      if model.state == 'DISABLE'
         error_msg = command || "#{target_name} #{cmd_name}"
         raise QueueError, "Queue '#{name}' is disabled. Command '#{error_msg}' not queued."
       end
+
+      result = Store.zrevrange("#{scope}:#{name}", 0, 0, with_scores: true)
+      id = result.empty? ? 1.0 : result[0][1].to_f + 1
+
+      command_data = build_command_data(username: username, command: command, target_name: target_name,
+                                        cmd_name: cmd_name, cmd_params: cmd_params, validate: validate, timeout: timeout)
+      Store.zadd("#{scope}:#{name}", id, command_data.to_json)
+      model.notify(kind: 'command')
+    end
+
+    # Build the hash that gets serialized into Redis. Always uses symbol keys so
+    # downstream code in this class can access values consistently. cmd_params is
+    # JSON-encoded as a string so binary data survives the round-trip via as_json.
+    def self.build_command_data(username:, command: nil, target_name: nil, cmd_name: nil, cmd_params: nil, validate: nil, timeout: nil)
+      command_data = { username: username, timestamp: Time.now.to_nsec_from_epoch }
+      if target_name && cmd_name
+        command_data[:target_name] = target_name
+        command_data[:cmd_name] = cmd_name
+        command_data[:cmd_params] = JSON.generate(cmd_params.as_json, allow_nan: true) if cmd_params
+      elsif command
+        command_data[:value] = command
+      else
+        raise QueueError, "Must provide either command string or target_name/cmd_name parameters"
+      end
+      command_data[:validate] = validate unless validate.nil?
+      command_data[:timeout] = timeout unless timeout.nil?
+      command_data
     end
 
     attr_accessor :name, :state
@@ -115,29 +118,19 @@ module OpenC3
       QueueTopic.write_notification(notification, scope: @scope)
     end
 
-    def insert_command(id, command_data)
+    def insert_command(id: nil, username:, command: nil, target_name: nil, cmd_name: nil, cmd_params: nil, validate: nil, timeout: nil)
       if @state == 'DISABLE'
-        if command_data['value']
-          command_name = command_data['value']
-        else
-          command_name = "#{command_data['target_name']} #{command_data['cmd_name']}"
-        end
+        command_name = command || "#{target_name} #{cmd_name}"
         raise QueueError, "Queue '#{@name}' is disabled. Command '#{command_name}' not queued."
       end
 
       unless id
         result = Store.zrevrange("#{@scope}:#{@name}", 0, 0, with_scores: true)
-        if result.empty?
-          id = 1.0
-        else
-          id = result[0][1].to_f + 1
-        end
+        id = result.empty? ? 1.0 : result[0][1].to_f + 1
       end
 
-      # Convert cmd_params values to JSON-safe format if present
-      if command_data['cmd_params']
-        command_data['cmd_params'] = JSON.generate(command_data['cmd_params'].as_json, allow_nan: true)
-      end
+      command_data = self.class.build_command_data(username: username, command: command, target_name: target_name,
+                                                   cmd_name: cmd_name, cmd_params: cmd_params, validate: validate, timeout: timeout)
       Store.zadd("#{@scope}:#{@name}", id, command_data.to_json)
       notify(kind: 'command')
     end
@@ -147,28 +140,14 @@ module OpenC3
         raise QueueError, "Queue '#{@name}' is disabled. Command at id #{id} not updated."
       end
 
-      # Check if command exists at the given id
       existing = Store.zrangebyscore("#{@scope}:#{@name}", id, id)
       if existing.empty?
         raise QueueError, "No command found at id #{id} in queue '#{@name}'"
       end
 
-      # Remove the existing command and add the new one at the same id
       Store.zremrangebyscore("#{@scope}:#{@name}", id, id)
-      command_data = { username: username, timestamp: Time.now.to_nsec_from_epoch }
-      if target_name && cmd_name
-        # New format: store target_name, cmd_name, and cmd_params separately
-        command_data[:target_name] = target_name
-        command_data[:cmd_name] = cmd_name
-        command_data[:cmd_params] = JSON.generate(cmd_params.as_json, allow_nan: true) if cmd_params
-      elsif command
-        # Legacy format: store command string for backwards compatibility
-        command_data[:value] = command
-      else
-        raise QueueError, "Must provide either command string or target_name/cmd_name parameters"
-      end
-      command_data[:validate] = validate unless validate.nil?
-      command_data[:timeout] = timeout unless timeout.nil?
+      command_data = self.class.build_command_data(username: username, command: command, target_name: target_name,
+                                                   cmd_name: cmd_name, cmd_params: cmd_params, validate: validate, timeout: timeout)
       Store.zadd("#{@scope}:#{@name}", id, command_data.to_json)
       notify(kind: 'command')
     end

--- a/openc3/lib/openc3/models/queue_model.rb
+++ b/openc3/lib/openc3/models/queue_model.rb
@@ -142,7 +142,7 @@ module OpenC3
       notify(kind: 'command')
     end
 
-    def update_command(id:, command:, username:, validate: nil, timeout: nil)
+    def update_command(id:, username:, command: nil, target_name: nil, cmd_name: nil, cmd_params: nil, validate: nil, timeout: nil)
       if @state == 'DISABLE'
         raise QueueError, "Queue '#{@name}' is disabled. Command at id #{id} not updated."
       end
@@ -155,7 +155,18 @@ module OpenC3
 
       # Remove the existing command and add the new one at the same id
       Store.zremrangebyscore("#{@scope}:#{@name}", id, id)
-      command_data = { username: username, value: command, timestamp: Time.now.to_nsec_from_epoch }
+      command_data = { username: username, timestamp: Time.now.to_nsec_from_epoch }
+      if target_name && cmd_name
+        # New format: store target_name, cmd_name, and cmd_params separately
+        command_data[:target_name] = target_name
+        command_data[:cmd_name] = cmd_name
+        command_data[:cmd_params] = JSON.generate(cmd_params.as_json, allow_nan: true) if cmd_params
+      elsif command
+        # Legacy format: store command string for backwards compatibility
+        command_data[:value] = command
+      else
+        raise QueueError, "Must provide either command string or target_name/cmd_name parameters"
+      end
       command_data[:validate] = validate unless validate.nil?
       command_data[:timeout] = timeout unless timeout.nil?
       Store.zadd("#{@scope}:#{@name}", id, command_data.to_json)

--- a/openc3/spec/models/queue_model_spec.rb
+++ b/openc3/spec/models/queue_model_spec.rb
@@ -103,7 +103,7 @@ module OpenC3
         QueueModel.queue_command("TEST", command: command, username: 'anonymous', scope: "DEFAULT")
 
         commands = Store.zrange("DEFAULT:TEST", 0, -1).map { |cmd| JSON.parse(cmd) }
-        expect(commands).to contain_exactly({ "username" => "anonymous", "value" => command, "validate" => true, "timeout" => nil, "timestamp" => anything })
+        expect(commands).to contain_exactly({ "username" => "anonymous", "value" => command, "validate" => true, "timestamp" => anything })
       end
 
       it "queues command when queue is in RELEASE state" do
@@ -114,7 +114,7 @@ module OpenC3
         QueueModel.queue_command("TEST", command: command, username: 'anonymous', scope: "DEFAULT")
 
         commands = Store.zrange("DEFAULT:TEST", 0, -1).map { |cmd| JSON.parse(cmd) }
-        expect(commands).to contain_exactly({ "username" => "anonymous", "value" => command, "validate" => true, "timeout" => nil, "timestamp" => anything })
+        expect(commands).to contain_exactly({ "username" => "anonymous", "value" => command, "validate" => true, "timestamp" => anything })
       end
 
       it "sends command notification" do
@@ -139,12 +139,12 @@ module OpenC3
         QueueModel.queue_command("TEST", command: command, username: 'anonymous', scope: "DEFAULT")
 
         commands = Store.zrange("DEFAULT:TEST", 0, -1).map { |cmd| JSON.parse(cmd) }
-        expect(commands).to contain_exactly({ "username" => "anonymous", "value" => first_command, "validate" => true, "timeout" => nil, "timestamp" => anything },
-          { "username" => "anonymous", "value" => command, "validate" => true, "timeout" => nil, "timestamp" => anything })
+        expect(commands).to contain_exactly({ "username" => "anonymous", "value" => first_command, "validate" => true, "timestamp" => anything },
+          { "username" => "anonymous", "value" => command, "validate" => true, "timestamp" => anything })
 
         list = model.list()
-        expect(list).to contain_exactly({ "username" => "anonymous", "value" => first_command, "validate" => true, "timeout" => nil, "timestamp" => anything, "id" => 1.0 },
-          { "username" => "anonymous", "value" => command, "validate" => true, "timeout" => nil, "timestamp" => anything, "id" => 2.0 })
+        expect(list).to contain_exactly({ "username" => "anonymous", "value" => first_command, "validate" => true, "timestamp" => anything, "id" => 1.0 },
+          { "username" => "anonymous", "value" => command, "validate" => true, "timestamp" => anything, "id" => 2.0 })
       end
 
       it "queues command with target_name, cmd_name, and cmd_params (new format)" do
@@ -161,7 +161,6 @@ module OpenC3
           "cmd_name" => "COLLECT",
           "cmd_params" => "{\"TYPE\":\"NORMAL\"}",
           "validate" => true,
-          "timeout" => nil,
           "timestamp" => anything
         })
       end
@@ -179,7 +178,6 @@ module OpenC3
           "target_name" => "INST",
           "cmd_name" => "ABORT",
           "validate" => true,
-          "timeout" => nil,
           "timestamp" => anything
         })
       end
@@ -330,7 +328,7 @@ module OpenC3
 
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
         model.create
-        model.insert_command(1, { username: "anonymous", value: "TGT CMD", timestamp: 12345 })
+        model.insert_command(id: 1, username: "anonymous", command: "TGT CMD")
         model.destroy
 
         queue = QueueModel.get(name: "TEST", scope: "DEFAULT")
@@ -355,12 +353,14 @@ module OpenC3
       it "inserts command data to the store" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command_data = { username: "anonymous", value: "TGT CMD", timestamp: 1 }
 
-        model.insert_command(1, command_data)
+        model.insert_command(id: 1, username: "anonymous", command: "TGT CMD")
 
         commands = Store.zrange("DEFAULT:TEST", 0, -1).map { |cmd| JSON.parse(cmd) }
-        expect(commands).to contain_exactly(command_data.transform_keys(&:to_s))
+        expect(commands.length).to eq(1)
+        expect(commands[0]["username"]).to eq("anonymous")
+        expect(commands[0]["value"]).to eq("TGT CMD")
+        expect(commands[0]).to have_key("timestamp")
       end
 
       it "sends command notification when inserting" do
@@ -369,16 +369,32 @@ module OpenC3
           scope: "DEFAULT"
         )
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        model.insert_command(1, { username: "anonymous", value: "TGT CMD", timestamp: 12345 })
+        model.insert_command(id: 1, username: "anonymous", command: "TGT CMD")
       end
 
       it "raises error when queue state is DISABLE" do
         model = QueueModel.new(name: "TEST", scope: "DEFAULT", state: "DISABLE")
-        command_data = { "username" => "anonymous", "value" => "TGT CMD", "timestamp" => 1 }
 
         expect {
-          model.insert_command(1, command_data)
+          model.insert_command(id: 1, username: "anonymous", command: "TGT CMD")
         }.to raise_error(QueueError, "Queue 'TEST' is disabled. Command 'TGT CMD' not queued.")
+      end
+
+      it "raises error when queue state is DISABLE with target_name/cmd_name" do
+        model = QueueModel.new(name: "TEST", scope: "DEFAULT", state: "DISABLE")
+
+        expect {
+          model.insert_command(id: 1, username: "anonymous", target_name: "INST", cmd_name: "ABORT")
+        }.to raise_error(QueueError, "Queue 'TEST' is disabled. Command 'INST ABORT' not queued.")
+      end
+
+      it "raises error when neither command nor target_name/cmd_name provided" do
+        allow(QueueTopic).to receive(:write_notification)
+        model = QueueModel.new(name: "TEST", scope: "DEFAULT")
+
+        expect {
+          model.insert_command(id: 1, username: "anonymous")
+        }.to raise_error(QueueError, "Must provide either command string or target_name/cmd_name parameters")
       end
 
       it "handles binary data in cmd_params when inserting" do
@@ -387,15 +403,9 @@ module OpenC3
 
         # Create a binary string parameter
         binary_data = "\xDE\xAD\xBE\xEF".b
-        command_data = {
-          'username' => "test_user",
-          'target_name' => "INST",
-          'cmd_name' => "UPLOAD",
-          'cmd_params' => { "DATA" => binary_data },
-          'timestamp' => Time.now.to_nsec_from_epoch
-        }
 
-        model.insert_command(1, command_data)
+        model.insert_command(id: 1, username: "test_user", target_name: "INST", cmd_name: "UPLOAD",
+                             cmd_params: { "DATA" => binary_data })
 
         # Verify the command was inserted successfully with binary data
         commands = Store.zrange("DEFAULT:TEST", 0, -1).map { |cmd| JSON.parse(cmd) }
@@ -414,16 +424,17 @@ module OpenC3
       it "updates existing command at given id" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        original_command = { username: "user1", value: "TGT CMD1", timestamp: 1000 }
 
-        model.insert_command(1.5, original_command)
+        model.insert_command(id: 1.5, username: "user1", command: "TGT CMD1")
+        original_timestamp = JSON.parse(Store.zrange("DEFAULT:TEST", 0, -1).first)["timestamp"]
+        sleep 0.001
         model.update_command(id: 1.5, command: "TGT CMD2", username: "user2")
 
         commands = Store.zrange("DEFAULT:TEST", 0, -1).map { |cmd| JSON.parse(cmd) }
         expect(commands.length).to eq(1)
         expect(commands[0]["username"]).to eq("user2")
         expect(commands[0]["value"]).to eq("TGT CMD2")
-        expect(commands[0]["timestamp"]).to be > 1000
+        expect(commands[0]["timestamp"]).to be > original_timestamp
       end
 
       it "raises error when updating non-existent command" do
@@ -437,7 +448,7 @@ module OpenC3
       it "sends command notification when updating" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        model.insert_command(1.0, { username: "user1", value: "TGT CMD1", timestamp: 1000 })
+        model.insert_command(id: 1.0, username: "user1", command: "TGT CMD1")
 
         expect(QueueTopic).to receive(:write_notification).with(
           hash_including('kind' => 'command'),
@@ -449,8 +460,8 @@ module OpenC3
       it "preserves command id when updating" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        model.insert_command(1.0, { username: "user1", value: "TGT CMD1", timestamp: 1000 })
-        model.insert_command(2.0, { username: "user1", value: "TGT CMD3", timestamp: 3000 })
+        model.insert_command(id: 1.0, username: "user1", command: "TGT CMD1")
+        model.insert_command(id: 2.0, username: "user1", command: "TGT CMD3")
 
         model.update_command(id: 1.0, command: "TGT CMD2", username: "user2")
 
@@ -466,7 +477,7 @@ module OpenC3
       it "raises error when queue state is DISABLE" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        model.insert_command(1.0, { username: "user1", value: "TGT CMD1", timestamp: 1000 })
+        model.insert_command(id: 1.0, username: "user1", command: "TGT CMD1")
 
         # Change state to DISABLE after inserting the command
         model.state = "DISABLE"
@@ -488,55 +499,37 @@ module OpenC3
       it "returns all commands in the queue" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "TGT CMD1", timestamp: 1000 }
-        command2 = { username: "user2", value: "TGT CMD2", timestamp: 2000 }
-        command3 = { username: "user3", value: "TGT CMD3", timestamp: 3000 }
 
-        model.insert_command(1, command1)
-        model.insert_command(2, command2)
-        model.insert_command(3, command3)
+        model.insert_command(id: 1, username: "user1", command: "TGT CMD1")
+        model.insert_command(id: 2, username: "user2", command: "TGT CMD2")
+        model.insert_command(id: 3, username: "user3", command: "TGT CMD3")
 
         result = model.list
         expect(result.length).to eql 3
-        one = command1.transform_keys(&:to_s)
-        one["id"] = 1.0
-        two = command2.transform_keys(&:to_s)
-        two["id"] = 2.0
-        three = command3.transform_keys(&:to_s)
-        three["id"] = 3.0
-        expect(result[0]).to eql one
-        expect(result[1]).to eql two
-        expect(result[2]).to eql three
+        expect(result[0]).to include("id" => 1.0, "username" => "user1", "value" => "TGT CMD1")
+        expect(result[1]).to include("id" => 2.0, "username" => "user2", "value" => "TGT CMD2")
+        expect(result[2]).to include("id" => 3.0, "username" => "user3", "value" => "TGT CMD3")
       end
 
       it "returns commands in FIFO order" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        first_command = { username: "user1", value: "FIRST_CMD", timestamp: 1000 }
-        second_command = { username: "user2", value: "SECOND_CMD", timestamp: 2000 }
 
-        model.insert_command(1, first_command)
-        model.insert_command(2, second_command)
+        model.insert_command(id: 1, username: "user1", command: "FIRST_CMD")
+        model.insert_command(id: 2, username: "user2", command: "SECOND_CMD")
 
         result = model.list
-        one = first_command.transform_keys(&:to_s)
-        one["id"] = 1.0
-        two = second_command.transform_keys(&:to_s)
-        two["id"] = 2.0
-        expect(result[0]).to eql one
-        expect(result[1]).to eql two
+        expect(result[0]).to include("id" => 1.0, "value" => "FIRST_CMD")
+        expect(result[1]).to include("id" => 2.0, "value" => "SECOND_CMD")
       end
 
       it "reflects queue state after remove operations" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "CMD1", timestamp: 1000 }
-        command2 = { username: "user2", value: "CMD2", timestamp: 2000 }
-        command3 = { username: "user3", value: "CMD3", timestamp: 3000 }
 
-        model.insert_command(1, command1)
-        model.insert_command(3, command3)
-        model.insert_command(2, command2)
+        model.insert_command(id: 1, username: "user1", command: "CMD1")
+        model.insert_command(id: 3, username: "user3", command: "CMD3")
+        model.insert_command(id: 2, username: "user2", command: "CMD2")
 
         expect(model.list.length).to eql 3
 
@@ -545,12 +538,8 @@ module OpenC3
         expect(result_removed).to_not be_nil
         result = model.list
         expect(result.length).to eql 2
-        two = command2.transform_keys(&:to_s)
-        two["id"] = 2.0
-        three = command3.transform_keys(&:to_s)
-        three["id"] = 3.0
-        expect(result[0]).to eql two
-        expect(result[1]).to eql three
+        expect(result[0]).to include("id" => 2.0, "value" => "CMD2")
+        expect(result[1]).to include("id" => 3.0, "value" => "CMD3")
       end
     end
 
@@ -681,19 +670,15 @@ module OpenC3
       it "removes the first command when no id is specified" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "CMD1", timestamp: 1000 }
-        command2 = { username: "user2", value: "CMD2", timestamp: 2000 }
-        command3 = { username: "user3", value: "CMD3", timestamp: 3000 }
 
-        model.insert_command(1.0, command1)
-        model.insert_command(2.0, command2)
-        model.insert_command(3.0, command3)
+        model.insert_command(id: 1.0, username: "user1", command: "CMD1")
+        model.insert_command(id: 2.0, username: "user2", command: "CMD2")
+        model.insert_command(id: 3.0, username: "user3", command: "CMD3")
 
         result = model.remove_command
 
         expect(result["username"]).to eq("user1")
         expect(result["value"]).to eq("CMD1")
-        expect(result["timestamp"]).to eq(1000)
         expect(result["id"]).to eq(1.0)
 
         # Verify the command was removed from the queue
@@ -706,19 +691,15 @@ module OpenC3
       it "removes command at specific id when id is provided" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "CMD1", timestamp: 1000 }
-        command2 = { username: "user2", value: "CMD2", timestamp: 2000 }
-        command3 = { username: "user3", value: "CMD3", timestamp: 3000 }
 
-        model.insert_command(1.0, command1)
-        model.insert_command(2.0, command2)
-        model.insert_command(3.0, command3)
+        model.insert_command(id: 1.0, username: "user1", command: "CMD1")
+        model.insert_command(id: 2.0, username: "user2", command: "CMD2")
+        model.insert_command(id: 3.0, username: "user3", command: "CMD3")
 
         result = model.remove_command(2.0)
 
         expect(result["username"]).to eq("user2")
         expect(result["value"]).to eq("CMD2")
-        expect(result["timestamp"]).to eq(2000)
         expect(result["id"]).to eq(2.0)
 
         # Verify the middle command was removed from the queue
@@ -731,9 +712,8 @@ module OpenC3
       it "returns nil when trying to remove non-existent id" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "CMD1", timestamp: 1000 }
 
-        model.insert_command(1.0, command1)
+        model.insert_command(id: 1.0, username: "user1", command: "CMD1")
 
         result = model.remove_command(5.0)
         expect(result).to be_nil
@@ -747,9 +727,8 @@ module OpenC3
       it "sends command notification when removing without id" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "CMD1", timestamp: 1000 }
 
-        model.insert_command(1.0, command1)
+        model.insert_command(id: 1.0, username: "user1", command: "CMD1")
 
         expect(QueueTopic).to receive(:write_notification).with(
           hash_including('kind' => 'command'),
@@ -762,11 +741,9 @@ module OpenC3
       it "sends command notification when removing with specific id" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "CMD1", timestamp: 1000 }
-        command2 = { username: "user2", value: "CMD2", timestamp: 2000 }
 
-        model.insert_command(1.0, command1)
-        model.insert_command(2.0, command2)
+        model.insert_command(id: 1.0, username: "user1", command: "CMD1")
+        model.insert_command(id: 2.0, username: "user2", command: "CMD2")
 
         expect(QueueTopic).to receive(:write_notification).with(
           hash_including('kind' => 'command'),
@@ -788,9 +765,8 @@ module OpenC3
       it "does not send notification when removing non-existent id" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "CMD1", timestamp: 1000 }
 
-        model.insert_command(1.0, command1)
+        model.insert_command(id: 1.0, username: "user1", command: "CMD1")
 
         expect(QueueTopic).not_to receive(:write_notification)
 
@@ -801,9 +777,8 @@ module OpenC3
       it "handles removing from single item queue" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "CMD1", timestamp: 1000 }
 
-        model.insert_command(1.0, command1)
+        model.insert_command(id: 1.0, username: "user1", command: "CMD1")
 
         result = model.remove_command
 
@@ -819,13 +794,10 @@ module OpenC3
       it "removes commands in FIFO order when called multiple times without id" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "FIRST", timestamp: 1000 }
-        command2 = { username: "user2", value: "SECOND", timestamp: 2000 }
-        command3 = { username: "user3", value: "THIRD", timestamp: 3000 }
 
-        model.insert_command(1.0, command1)
-        model.insert_command(2.0, command2)
-        model.insert_command(3.0, command3)
+        model.insert_command(id: 1.0, username: "user1", command: "FIRST")
+        model.insert_command(id: 2.0, username: "user2", command: "SECOND")
+        model.insert_command(id: 3.0, username: "user3", command: "THIRD")
 
         first_pop = model.remove_command
         expect(first_pop["value"]).to eq("FIRST")
@@ -847,11 +819,9 @@ module OpenC3
       it "handles fractional indices correctly" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "CMD1", timestamp: 1000 }
-        command2 = { username: "user2", value: "CMD2", timestamp: 2000 }
 
-        model.insert_command(1.5, command1)
-        model.insert_command(2.7, command2)
+        model.insert_command(id: 1.5, username: "user1", command: "CMD1")
+        model.insert_command(id: 2.7, username: "user2", command: "CMD2")
 
         result = model.remove_command(1.5)
 
@@ -866,9 +836,8 @@ module OpenC3
       it "raises error when queue state is DISABLE" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "CMD1", timestamp: 1000 }
 
-        model.insert_command(1.0, command1)
+        model.insert_command(id: 1.0, username: "user1", command: "CMD1")
 
         # Change state to DISABLE after inserting the command
         model.state = "DISABLE"
@@ -881,9 +850,8 @@ module OpenC3
       it "raises error when queue state is DISABLE and removing by id" do
         allow(QueueTopic).to receive(:write_notification)
         model = QueueModel.new(name: "TEST", scope: "DEFAULT")
-        command1 = { username: "user1", value: "CMD1", timestamp: 1000 }
 
-        model.insert_command(1.0, command1)
+        model.insert_command(id: 1.0, username: "user1", command: "CMD1")
 
         # Change state to DISABLE after inserting the command
         model.state = "DISABLE"
@@ -901,11 +869,11 @@ module OpenC3
         model.create
 
         # Add commands using both methods
-        model.insert_command(nil, { username: "user1", value: "CMD1", timestamp: 1000 })
+        model.insert_command(username: "user1", command: "CMD1")
         QueueModel.queue_command("TEST", command: "CMD2", username: "user2", scope: "DEFAULT")
-        model.insert_command(nil, { username: "user3", value: "CMD3", timestamp: 3000 })
+        model.insert_command(username: "user3", command: "CMD3")
         QueueModel.queue_command("TEST", command: "CMD4", username: "user4", scope: "DEFAULT")
-        model.insert_command(nil, { username: "user5", value: "CMD5", timestamp: 5000 })
+        model.insert_command(username: "user5", command: "CMD5")
 
         # Get all commands with their scores
         commands_withscores = Store.zrange("DEFAULT:TEST", 0, -1, withscores: true)


### PR DESCRIPTION
Move convertToValue from CommandSender to cmdUtilities.js
queues_controller.rb and queue_model.rb now support new syntax