### PR TITLE
[Enhancement] COSMOS 6 -- Ability to toggle Script Runner Locking ability

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/FileOpenSaveDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/FileOpenSaveDialog.vue
@@ -13,7 +13,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -102,6 +102,7 @@
                 ref="submitBtn"
                 type="submit"
                 color="primary"
+                variant="elevated"
                 class="mx-2"
                 data-test="file-open-save-submit-btn"
                 :disabled="disableButtons || !!error"

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/EditorSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/EditorSettings.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -22,6 +22,15 @@
     <v-card-subtitle>
       Settings for the code editors built into COSMOS (e.g. in Script Runner)
     </v-card-subtitle>
+    <v-alert v-model="errorLoading" type="error" closable density="compact">
+      Error loading previous configuration due to {{ errorText }}
+    </v-alert>
+    <v-alert v-model="errorSaving" type="error" closable density="compact">
+      Error saving due to {{ errorText }}
+    </v-alert>
+    <v-alert v-model="successSaving" type="success" closable density="compact">
+      Saved!
+    </v-alert>
     <v-card-text class="pb-0">
       <v-select
         v-model="defaultLanguage"
@@ -34,6 +43,15 @@
         data-test="default-language"
       />
       <v-switch v-model="vimMode" label="Vim mode" color="primary" />
+      <v-switch
+        v-model="scriptLockingEnabled"
+        label="Script File Locking - When enabled, a script being edited
+        by one user is read-only for other users until they explicitly force
+        unlock. Disable to allow multiple users to edit the same script
+        concurrently (last save wins)."
+        color="primary"
+        data-test="script-locking-enabled"
+      />
     </v-card-text>
     <v-card-actions>
       <v-btn
@@ -50,11 +68,16 @@
 
 <script>
 import { AceEditorUtils } from '@/components/ace'
+import Settings from './settings.js'
+
+const SCRIPT_LOCKING_SETTING = 'script_runner_locking'
 
 export default {
+  mixins: [Settings],
   data() {
     return {
       vimMode: AceEditorUtils.isVimModeEnabled(),
+      scriptLockingEnabled: true,
       defaultLanguage: AceEditorUtils.getDefaultScriptingLanguage(),
       languageOptions: [
         { text: 'Ruby', value: 'ruby' },
@@ -62,10 +85,19 @@ export default {
       ],
     }
   },
+  created() {
+    this.loadSetting(SCRIPT_LOCKING_SETTING)
+  },
   methods: {
     save: function () {
       AceEditorUtils.setVimMode(this.vimMode)
       AceEditorUtils.setDefaultScriptingLanguage(this.defaultLanguage)
+      this.saveSetting(SCRIPT_LOCKING_SETTING, this.scriptLockingEnabled)
+    },
+    parseSetting: function (response) {
+      if (response !== null && response !== undefined) {
+        this.scriptLockingEnabled = response
+      }
     },
   },
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/EditorSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/EditorSettings.vue
@@ -29,7 +29,7 @@
       Error saving due to {{ errorText }}
     </v-alert>
     <v-alert v-model="successSaving" type="success" closable density="compact">
-      Saved!
+      Saved! (Refresh the page to see changes)
     </v-alert>
     <v-card-text class="pb-0">
       <v-select

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -1228,16 +1228,19 @@ export default {
       .catch((error) => {
         // Do nothing
       })
-    this.api
-      .get_setting('script_runner_locking')
-      .then((response) => {
-        if (response !== null && response !== undefined) {
-          this.lockingEnabled = response
-        }
-      })
-      .catch((error) => {
-        // Do nothing
-      })
+    // Await this so that lockingEnabled is known before any file load /
+    // setFile runs. Otherwise isLocked can briefly compute true with the
+    // default and flash the editor into read-only mode before settling.
+    try {
+      const lockingResponse = await this.api.get_setting(
+        'script_runner_locking',
+      )
+      if (lockingResponse !== null && lockingResponse !== undefined) {
+        this.lockingEnabled = lockingResponse
+      }
+    } catch (error) {
+      // Keep default (true)
+    }
 
     this.updateOverridesCount()
 

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -13,7 +13,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2025, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -863,6 +863,7 @@ export default {
       criticalCmdUser: null,
       displayCriticalCmd: false,
       editorBoxSize: 50,
+      lockingEnabled: true,
     }
   },
   computed: {
@@ -905,6 +906,9 @@ export default {
       return this.scriptEnvironment.env.length > 0
     },
     isLocked: function () {
+      if (!this.lockingEnabled) {
+        return false
+      }
       return !!this.lockedBy
     },
     // Returns the currently shown filename
@@ -1219,6 +1223,16 @@ export default {
       .then((response) => {
         if (response) {
           this.timeZone = response
+        }
+      })
+      .catch((error) => {
+        // Do nothing
+      })
+    this.api
+      .get_setting('script_runner_locking')
+      .then((response) => {
+        if (response !== null && response !== undefined) {
+          this.lockingEnabled = response
         }
       })
       .catch((error) => {

--- a/openc3/lib/openc3/accessors/json_accessor.rb
+++ b/openc3/lib/openc3/accessors/json_accessor.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2023 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -25,7 +25,7 @@ require 'openc3/accessors/accessor'
 OpenC3.disable_warnings do
   class JsonPath
     def self.process_object(obj_or_str, opts = {})
-      obj_or_str.is_a?(String) ? MultiJson.load(obj_or_str, max_nesting: opts[:max_nesting], create_additions: true, allow_nan: true) : obj_or_str
+      obj_or_str.is_a?(String) ? JSON.parse(obj_or_str, max_nesting: opts[:max_nesting], create_additions: true, allow_nan: true) : obj_or_str
     end
   end
 end

--- a/openc3/lib/openc3/models/activity_model.rb
+++ b/openc3/lib/openc3/models/activity_model.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2024, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -33,6 +33,11 @@ module OpenC3
 
   class ActivityModel < Model
     MAX_DURATION = Time::SEC_PER_DAY
+    # Grace window (in seconds) to allow creating activities slightly in the past.
+    # This handles race conditions where real-time activity notifications arrive
+    # after the start time has already passed (e.g. from external systems).
+    # This is consistent with the -15 second window in the timeline microservice.
+    START_GRACE_SECONDS = 15
     PRIMARY_KEY = '__openc3_timelines'.freeze # MUST be equal to `TimelineModel::PRIMARY_KEY` minus the leading __
     # See run_activity(activity) in openc3/lib/openc3/microservices/timeline_microservice.rb
     VALID_KINDS = %w(command script reserve expire)
@@ -217,7 +222,7 @@ module OpenC3
     end
 
     # validate the input to the rules we have created for timelines.
-    # - A task's start MUST NOT be in the past.
+    # - A task's start MUST NOT be more than START_GRACE_SECONDS in the past.
     # - A task's start MUST be before the stop.
     # - A task CAN NOT be longer than MAX_DURATION (86400) in seconds.
     # - A task MUST have a kind.
@@ -235,8 +240,8 @@ module OpenC3
       rescue NoMethodError
         raise ActivityInputError.new "start and stop must be seconds: #{start}, #{stop}"
       end
-      if now_f >= start and kind != 'expire'
-        raise ActivityInputError.new "activity must be in the future, current_time: #{now_f} vs #{start}"
+      if now_f >= start + START_GRACE_SECONDS and kind != 'expire'
+        raise ActivityInputError.new "activity must not be more than #{START_GRACE_SECONDS} seconds in the past, current_time: #{now_f} vs #{start}"
       elsif duration > MAX_DURATION and kind != 'expire'
         raise ActivityInputError.new "activity can not be longer than #{MAX_DURATION} seconds"
       elsif duration <= 0

--- a/openc3/spec/models/activity_model_spec.rb
+++ b/openc3/spec/models/activity_model_spec.rb
@@ -671,6 +671,8 @@ module OpenC3
       end
 
       it "allows activities within the grace window" do
+        name = "foobar"
+        scope = "scope"
         now_f = Time.now.to_f
         start = now_f - 10
         stop = now_f + 50
@@ -678,6 +680,8 @@ module OpenC3
       end
 
       it "rejects activities beyond the grace window" do
+        name = "foobar"
+        scope = "scope"
         now_f = Time.now.to_f
         start = now_f - 20
         stop = now_f + 40

--- a/openc3/spec/models/activity_model_spec.rb
+++ b/openc3/spec/models/activity_model_spec.rb
@@ -667,7 +667,7 @@ module OpenC3
         stop = (dt_now + (1.0 / 24.0)).strftime("%s").to_i
         expect {
           ActivityModel.new(name: name, scope: scope, start: start, stop: stop, kind: "COMMAND", data: {})
-      }.to raise_error(ActivityInputError, /activity must not be more than #{ActivityModel::START_GRACE_SECONDS} seconds in the past/)
+        }.to raise_error(ActivityInputError, /activity must not be more than #{ActivityModel::START_GRACE_SECONDS} seconds in the past/)
       end
 
       it "allows activities within the grace window" do

--- a/openc3/spec/models/activity_model_spec.rb
+++ b/openc3/spec/models/activity_model_spec.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2024, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -659,7 +659,7 @@ module OpenC3
         }.to raise_error(ActivityInputError)
       end
 
-      it "raises error due to start before now" do
+      it "raises error due to start too far in the past" do
         name = "foobar"
         scope = "scope"
         dt_now = DateTime.now
@@ -667,7 +667,23 @@ module OpenC3
         stop = (dt_now + (1.0 / 24.0)).strftime("%s").to_i
         expect {
           ActivityModel.new(name: name, scope: scope, start: start, stop: stop, kind: "COMMAND", data: {})
-        }.to raise_error(ActivityInputError, /activity must be in the future/)
+      }.to raise_error(ActivityInputError, /activity must not be more than #{ActivityModel::START_GRACE_SECONDS} seconds in the past/)
+      end
+
+      it "allows activities within the grace window" do
+        now_f = Time.now.to_f
+        start = now_f - 10
+        stop = now_f + 50
+        ActivityModel.new(name: name, scope: scope, start: start, stop: stop, kind: "COMMAND", data: {})
+      end
+
+      it "rejects activities beyond the grace window" do
+        now_f = Time.now.to_f
+        start = now_f - 20
+        stop = now_f + 40
+        expect {
+          ActivityModel.new(name: name, scope: scope, start: start, stop: stop, kind: "COMMAND", data: {})
+        }.to raise_error(ActivityInputError, /activity must not be more than #{ActivityModel::START_GRACE_SECONDS} seconds in the past/)
       end
 
       it "allows EXPIRE activities with start before now" do


### PR DESCRIPTION
Toggle added to the settings to turn on/off the Script Runner locking ability
Nothing modified on the server-side -- mostly a UI update.

I'm also cherry-picking in the changes made from https://github.com/OpenC3/cosmos/pull/3009 into this