### PR TITLE
fix(decom): init limits_response_queue before sync_system

### DIFF
--- a/openc3/lib/openc3/microservices/decom_microservice.rb
+++ b/openc3/lib/openc3/microservices/decom_microservice.rb
@@ -94,13 +94,15 @@ module OpenC3
       @limits_event_topic = "#{@scope}__openc3_limits_events"
       @topics << @limits_event_topic
       Topic.update_topic_offsets(@topics, db_shard: @db_shard)
+      # Initialize before assigning limits_change_callback - sync_system below
+      # can fire the callback synchronously for any persisted-disabled items.
+      @limits_response_queue = Queue.new
+      @limits_response_thread = nil
       System.telemetry.limits_change_callback = method(:limits_change_callback)
       LimitsEventTopic.sync_system(scope: @scope)
       @error_count = 0
       @metric.set(name: 'decom_total', value: @count, type: 'counter')
       @metric.set(name: 'decom_error_total', value: @error_count, type: 'counter')
-      @limits_response_queue = Queue.new
-      @limits_response_thread = nil
     end
 
     def run

--- a/openc3/python/openc3/microservices/decom_microservice.py
+++ b/openc3/python/openc3/microservices/decom_microservice.py
@@ -110,13 +110,15 @@ class DecomMicroservice(Microservice):
         self.limits_event_topic = f"{self.scope}__openc3_limits_events"
         self.topics.append(self.limits_event_topic)
         Topic.update_topic_offsets(self.topics, db_shard=self.db_shard)
+        # Initialize before set_limits_change_callback - sync_system below can
+        # fire the callback synchronously for any persisted-disabled items.
+        self.limits_response_queue = queue.Queue()
+        self.limits_response_thread = None
         System.telemetry.set_limits_change_callback(self.limits_change_callback)
         LimitsEventTopic.sync_system(scope=self.scope)
         self.error_count = 0
         self.metric.set(name="decom_total", value=self.count, type="counter")
         self.metric.set(name="decom_error_total", value=self.error_count, type="counter")
-        self.limits_response_queue = queue.Queue()
-        self.limits_response_thread = None
 
     def run(self):
         self.limits_response_thread = LimitsResponseThread(

--- a/openc3/python/test/microservices/test_decom_microservice.py
+++ b/openc3/python/test/microservices/test_decom_microservice.py
@@ -324,6 +324,7 @@ class TestDecomMicroservice(unittest.TestCase):
 
         class NoOpLimitsResponse(LimitsResponse):
             def call(self, packet, item, old_limits_state):
+                # Simple stub to test the callback
                 pass
 
         packet = System.telemetry.packet("INST", "HEALTH_STATUS")

--- a/openc3/python/test/microservices/test_decom_microservice.py
+++ b/openc3/python/test/microservices/test_decom_microservice.py
@@ -10,6 +10,7 @@
 # if purchased from OpenC3, Inc.
 
 import contextlib
+import json
 import re
 import threading
 import time
@@ -27,6 +28,7 @@ from openc3.system.system import System
 from openc3.topics.limits_event_topic import LimitsEventTopic
 from openc3.topics.telemetry_topic import TelemetryTopic
 from openc3.topics.topic import Topic
+from openc3.utilities.store import Store
 from test.test_helper import capture_io, mock_redis, setup_system
 
 
@@ -311,6 +313,47 @@ class TestDecomMicroservice(unittest.TestCase):
 
         # Verify that even though the limits response sleeps for 0.1s, the decom thread is not blocked
         self.assertLess(self.dm.metric.data["decom_duration_seconds"]["value"], 0.02)
+
+    def test_constructor_handles_disabled_limits_during_sync_system(self):
+        # Regression: limits_response_queue must be initialized before the
+        # limits_change_callback is registered. LimitsEventTopic.sync_system
+        # (called from __init__) calls System.limits.disable on items persisted
+        # as disabled, which fires the callback - which writes to the queue.
+        self.dm.shutdown()
+        self.dm_thread.join()
+
+        class NoOpLimitsResponse(LimitsResponse):
+            def call(self, packet, item, old_limits_state):
+                pass
+
+        packet = System.telemetry.packet("INST", "HEALTH_STATUS")
+        packet.get_item("TEMP1").limits.response = NoOpLimitsResponse()
+
+        Store.hset(
+            "DEFAULT__current_limits_settings",
+            "INST__HEALTH_STATUS__TEMP1",
+            json.dumps(
+                {
+                    "enabled": False,
+                    "persistence_setting": 1,
+                    "DEFAULT": {
+                        "red_low": -80.0,
+                        "yellow_low": -70.0,
+                        "yellow_high": 60.0,
+                        "red_high": 80.0,
+                    },
+                }
+            ),
+        )
+
+        # Before the fix this raised AttributeError: 'DecomMicroservice'
+        # object has no attribute 'limits_response_queue'.
+        self.dm = DecomMicroservice("DEFAULT__DECOM__INST_INT")
+        self.assertEqual(self.dm.limits_response_queue.qsize(), 1)
+        # Restart the run thread so tearDown can shut it down cleanly.
+        self.dm_thread = threading.Thread(target=self.dm.run)
+        self.dm_thread.start()
+        time.sleep(0.01)
 
     def test_handles_exceptions_in_limits_responses(self):
         class BadLimitsResponse(LimitsResponse):

--- a/openc3/spec/microservices/decom_microservice_spec.rb
+++ b/openc3/spec/microservices/decom_microservice_spec.rb
@@ -222,7 +222,9 @@ module OpenC3
         @dm_thread.join
 
         klass = Class.new(LimitsResponse) do
-          def call(packet, item, old_limits_state); end
+          def call(_packet, _item, _old_limits_state)
+            # Simple stub to test the callback
+          end
         end
         System.telemetry.packet('INST', 'HEALTH_STATUS').get_item('TEMP1').limits.response = klass.new
 

--- a/openc3/spec/microservices/decom_microservice_spec.rb
+++ b/openc3/spec/microservices/decom_microservice_spec.rb
@@ -211,6 +211,44 @@ module OpenC3
         expect(@dm.instance_variable_get("@metric").data['decom_duration_seconds']['value']).to be < 0.01
       end
 
+      it "initializes limits_response_queue before sync_system can fire the callback" do
+        # Regression: @limits_response_queue must be initialized before the
+        # limits_change_callback is registered. LimitsEventTopic.sync_system
+        # (called from initialize) calls System.limits.disable on items
+        # persisted as disabled, which fires the callback - which writes to
+        # @limits_response_queue. Without the fix the callback hits a nil
+        # queue and raises NoMethodError on `<<`.
+        @dm.shutdown
+        @dm_thread.join
+
+        klass = Class.new(LimitsResponse) do
+          def call(packet, item, old_limits_state); end
+        end
+        System.telemetry.packet('INST', 'HEALTH_STATUS').get_item('TEMP1').limits.response = klass.new
+
+        Store.hset(
+          "DEFAULT__current_limits_settings",
+          "INST__HEALTH_STATUS__TEMP1",
+          JSON.generate({
+            'enabled' => false,
+            'persistence_setting' => 1,
+            'DEFAULT' => {
+              'red_low' => -80.0,
+              'yellow_low' => -70.0,
+              'yellow_high' => 60.0,
+              'red_high' => 80.0,
+            },
+          })
+        )
+
+        expect { @dm = DecomMicroservice.new("DEFAULT__DECOM__INST_INT") }.not_to raise_error
+        queue = @dm.instance_variable_get("@limits_response_queue")
+        expect(queue).not_to be_nil
+        expect(queue.size).to eql(1)
+        @dm_thread = Thread.new { @dm.run }
+        sleep 0.001
+      end
+
       it "handles exceptions in limits responses" do
         class BadLimitsResponse < LimitsResponse
           def call(packet, item, old_limits_state)


### PR DESCRIPTION
LimitsEventTopic.sync_system can fire limits_change_callback for any items persisted as disabled, but the queue the callback writes to was initialized after callback registration - causing AttributeError in Python and NoMethodError in Ruby on startup.

closes #3214
