### PR TITLE
re-add missing 'extra' data to msg_hash [!3335]

### DIFF
--- a/openc3/lib/openc3/topics/command_topic.rb
+++ b/openc3/lib/openc3/topics/command_topic.rb
@@ -33,6 +33,7 @@ module OpenC3
                    received_count: packet.received_count,
                    stored: packet.stored.to_s,
                    buffer: packet.buffer(false) }
+      msg_hash[:extra] = JSON.generate(packet.extra.as_json, allow_nan: true) if packet.extra
       db_shard = Store.db_shard_for_target(packet.target_name, scope: scope)
       EphemeralStoreQueued.instance(db_shard: db_shard).write_topic(topic, msg_hash)
     end

--- a/openc3/lib/openc3/topics/telemetry_decom_topic.rb
+++ b/openc3/lib/openc3/topics/telemetry_decom_topic.rb
@@ -43,6 +43,7 @@ module OpenC3
           :received_count => packet.received_count,
           :json_data => json_data,
         }
+        msg_hash[:extra] = JSON.generate(packet.extra.as_json, allow_nan: true) if packet.extra
         db_shard = Store.db_shard_for_target(packet.target_name, scope: scope)
         Topic.write_topic("#{scope}__DECOM__{#{packet.target_name}}__#{packet.packet_name}", msg_hash, id, db_shard: db_shard)
 

--- a/openc3/python/openc3/topics/command_topic.py
+++ b/openc3/python/openc3/topics/command_topic.py
@@ -35,6 +35,8 @@ class CommandTopic(Topic):
             "stored": str(packet.stored),
             "buffer": bytes(packet.buffer_no_copy()),
         }
+        if packet.extra:
+            msg_hash["extra"] = json.dumps(packet.extra)
         db_shard = Store.db_shard_for_target(packet.target_name, scope=scope)
         EphemeralStoreQueued.instance(db_shard=db_shard).write_topic(topic, msg_hash)
 

--- a/openc3/python/openc3/topics/telemetry_decom_topic.py
+++ b/openc3/python/openc3/topics/telemetry_decom_topic.py
@@ -42,6 +42,8 @@ class TelemetryDecomTopic(Topic):
             "received_count": packet.received_count,
             "json_data": json_data,
         }
+        if packet.extra:
+            msg_hash["extra"] = json.dumps(packet.extra, cls=JsonEncoder)
         db_shard = Store.db_shard_for_target(packet.target_name, scope=scope)
         Topic.write_topic(
             f"{scope}__DECOM__{{{packet.target_name}}}__{packet.packet_name}",

--- a/openc3/python/test/topics/test_command_topic.py
+++ b/openc3/python/test/topics/test_command_topic.py
@@ -15,7 +15,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from openc3.topics.command_topic import CommandTopic
-from test.test_helper import *
+from test.test_helper import mock_redis
 
 
 class TestCommandTopic(unittest.TestCase):

--- a/openc3/python/test/topics/test_command_topic.py
+++ b/openc3/python/test/topics/test_command_topic.py
@@ -1,0 +1,81 @@
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+import datetime
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from openc3.topics.command_topic import CommandTopic
+from test.test_helper import *
+
+
+class TestCommandTopic(unittest.TestCase):
+    def setUp(self):
+        mock_redis(self)
+        self.captured = {}
+
+        def fake_write_topic(topic, msg_hash):
+            self.captured["topic"] = topic
+            self.captured["msg_hash"] = msg_hash
+
+        self.store_instance = MagicMock()
+        self.store_instance.write_topic.side_effect = fake_write_topic
+
+        instance_patch = patch(
+            "openc3.topics.command_topic.EphemeralStoreQueued.instance",
+            return_value=self.store_instance,
+        )
+        instance_patch.start()
+        self.addCleanup(instance_patch.stop)
+
+        shard_patch = patch(
+            "openc3.topics.command_topic.Store.db_shard_for_target",
+            return_value=0,
+        )
+        shard_patch.start()
+        self.addCleanup(shard_patch.stop)
+
+    def _make_packet(self, extra=None):
+        packet = MagicMock()
+        packet.target_name = "TARGET"
+        packet.packet_name = "COMMAND"
+        packet.packet_time = datetime.datetime.now()
+        packet.received_time = datetime.datetime.now()
+        packet.received_count = 1
+        packet.stored = False
+        packet.buffer_no_copy.return_value = b"\x01\x02\x03\x04"
+        packet.extra = extra
+        return packet
+
+    def test_writes_to_correct_topic(self):
+        CommandTopic.write_packet(self._make_packet(), scope="DEFAULT")
+        self.assertEqual(self.captured["topic"], "DEFAULT__COMMAND__{TARGET}__COMMAND")
+        msg_hash = self.captured["msg_hash"]
+        self.assertEqual(msg_hash["target_name"], "TARGET")
+        self.assertEqual(msg_hash["packet_name"], "COMMAND")
+        self.assertEqual(msg_hash["received_count"], 1)
+        self.assertEqual(msg_hash["buffer"], b"\x01\x02\x03\x04")
+
+    def test_includes_extra_when_set(self):
+        extra = {"foo": "bar", "count": 42}
+        CommandTopic.write_packet(self._make_packet(extra=extra), scope="DEFAULT")
+        self.assertIn("extra", self.captured["msg_hash"])
+        self.assertEqual(json.loads(self.captured["msg_hash"]["extra"]), extra)
+
+    def test_omits_extra_when_none(self):
+        CommandTopic.write_packet(self._make_packet(extra=None), scope="DEFAULT")
+        self.assertNotIn("extra", self.captured["msg_hash"])
+
+    def test_omits_extra_when_empty_dict(self):
+        # Falsy extra (empty dict) should not produce an extra field
+        CommandTopic.write_packet(self._make_packet(extra={}), scope="DEFAULT")
+        self.assertNotIn("extra", self.captured["msg_hash"])

--- a/openc3/python/test/topics/test_telemetry_decom_topic.py
+++ b/openc3/python/test/topics/test_telemetry_decom_topic.py
@@ -1,0 +1,96 @@
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+import datetime
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from openc3.topics.telemetry_decom_topic import TelemetryDecomTopic
+from test.test_helper import *
+
+
+class TestTelemetryDecomTopic(unittest.TestCase):
+    def setUp(self):
+        mock_redis(self)
+        self.captured = {}
+
+        def fake_write_topic(topic, msg_hash, id, db_shard=None):
+            self.captured["topic"] = topic
+            self.captured["msg_hash"] = msg_hash
+            self.captured["id"] = id
+
+        write_patch = patch(
+            "openc3.topics.telemetry_decom_topic.Topic.write_topic",
+            side_effect=fake_write_topic,
+        )
+        write_patch.start()
+        self.addCleanup(write_patch.stop)
+
+        build_patch = patch(
+            "openc3.topics.telemetry_decom_topic.CvtModel.build_json_from_packet",
+            return_value={"TEMP1": 1.0},
+        )
+        build_patch.start()
+        self.addCleanup(build_patch.stop)
+
+        self.set_json_mock = MagicMock()
+        set_patch = patch(
+            "openc3.topics.telemetry_decom_topic.CvtModel.set_json",
+            new=self.set_json_mock,
+        )
+        set_patch.start()
+        self.addCleanup(set_patch.stop)
+
+        shard_patch = patch(
+            "openc3.topics.telemetry_decom_topic.Store.db_shard_for_target",
+            return_value=0,
+        )
+        shard_patch.start()
+        self.addCleanup(shard_patch.stop)
+
+    def _make_packet(self, extra=None, stored=False):
+        packet = MagicMock()
+        packet.target_name = "TARGET"
+        packet.packet_name = "PKT"
+        packet.packet_time = datetime.datetime.now()
+        packet.received_time = datetime.datetime.now()
+        packet.received_count = 5
+        packet.stored = stored
+        packet.extra = extra
+        return packet
+
+    def test_writes_to_correct_decom_topic(self):
+        TelemetryDecomTopic.write_packet(self._make_packet(), scope="DEFAULT")
+        self.assertEqual(self.captured["topic"], "DEFAULT__DECOM__{TARGET}__PKT")
+        msg_hash = self.captured["msg_hash"]
+        self.assertEqual(msg_hash["target_name"], "TARGET")
+        self.assertEqual(msg_hash["packet_name"], "PKT")
+        self.assertEqual(msg_hash["received_count"], 5)
+        self.assertIn("json_data", msg_hash)
+
+    def test_includes_extra_when_set(self):
+        extra = {"foo": "bar", "count": 42}
+        TelemetryDecomTopic.write_packet(self._make_packet(extra=extra), scope="DEFAULT")
+        self.assertIn("extra", self.captured["msg_hash"])
+        self.assertEqual(json.loads(self.captured["msg_hash"]["extra"]), extra)
+
+    def test_omits_extra_when_none(self):
+        TelemetryDecomTopic.write_packet(self._make_packet(extra=None), scope="DEFAULT")
+        self.assertNotIn("extra", self.captured["msg_hash"])
+
+    def test_updates_cvt_when_not_stored(self):
+        TelemetryDecomTopic.write_packet(self._make_packet(stored=False), scope="DEFAULT")
+        self.set_json_mock.assert_called_once()
+
+    def test_skips_cvt_when_stored(self):
+        TelemetryDecomTopic.write_packet(self._make_packet(stored=True), scope="DEFAULT")
+        self.set_json_mock.assert_not_called()

--- a/openc3/python/test/topics/test_telemetry_decom_topic.py
+++ b/openc3/python/test/topics/test_telemetry_decom_topic.py
@@ -15,7 +15,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from openc3.topics.telemetry_decom_topic import TelemetryDecomTopic
-from test.test_helper import *
+from test.test_helper import mock_redis
 
 
 class TestTelemetryDecomTopic(unittest.TestCase):

--- a/openc3/python/test/utilities/test_logger.py
+++ b/openc3/python/test/utilities/test_logger.py
@@ -11,13 +11,13 @@
 
 import json
 import os
+import sys
 import time
 import unittest
 from io import StringIO
-from unittest.mock import *
+from unittest.mock import patch
 
 from openc3.utilities.logger import Logger
-from test.test_helper import *
 
 
 class TestLogger(unittest.TestCase):
@@ -98,6 +98,12 @@ class TestLogMessage(unittest.TestCase):
         Logger.no_store = True
         Logger.microservice_name = None
         Logger.detail_string = None
+        # conftest imports openc3.utilities.logger before any test sets
+        # OPENC3_NO_STORE, so the module-level constant is None. Patch it so
+        # newly-constructed Logger instances skip the EphemeralStoreQueued write.
+        no_store_patch = patch("openc3.utilities.logger.OPENC3_NO_STORE", "1")
+        no_store_patch.start()
+        self.addCleanup(no_store_patch.stop)
 
     def tearDown(self):
         sys.stdout = sys.__stdout__

--- a/openc3/spec/topics/command_topic_spec.rb
+++ b/openc3/spec/topics/command_topic_spec.rb
@@ -63,6 +63,24 @@ module OpenC3
         end
         CommandTopic.write_packet(packet, scope: 'DEFAULT')
       end
+
+      it "includes extra field when packet.extra is set" do
+        packet.extra = { 'foo' => 'bar', 'count' => 42 }
+        store_instance = EphemeralStoreQueued.instance(db_shard: 0)
+        expect(store_instance).to receive(:write_topic) do |_topic, msg_hash|
+          expect(msg_hash[:extra]).to eq(JSON.generate({ 'foo' => 'bar', 'count' => 42 }))
+        end
+        CommandTopic.write_packet(packet, scope: 'DEFAULT')
+      end
+
+      it "omits extra field when packet.extra is nil" do
+        packet.extra = nil
+        store_instance = EphemeralStoreQueued.instance(db_shard: 0)
+        expect(store_instance).to receive(:write_topic) do |_topic, msg_hash|
+          expect(msg_hash).not_to have_key(:extra)
+        end
+        CommandTopic.write_packet(packet, scope: 'DEFAULT')
+      end
     end
 
     describe "self.send_command" do

--- a/openc3/spec/topics/telemetry_decom_topic_spec.rb
+++ b/openc3/spec/topics/telemetry_decom_topic_spec.rb
@@ -1,0 +1,82 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+
+require 'spec_helper'
+require 'openc3/topics/telemetry_decom_topic'
+require 'openc3/packets/packet'
+require 'openc3/models/cvt_model'
+
+module OpenC3
+  describe TelemetryDecomTopic do
+    before(:each) do
+      mock_redis()
+      allow(Topic).to receive(:write_topic)
+      allow(CvtModel).to receive(:build_json_from_packet).and_return({ 'TEMP1' => 1.0 })
+      allow(CvtModel).to receive(:set_json)
+    end
+
+    describe "self.write_packet" do
+      let(:packet) do
+        packet = Packet.new('TARGET', 'PKT')
+        packet.received_time = Time.now
+        packet.packet_time = Time.now
+        packet.received_count = 5
+        packet.stored = false
+        packet
+      end
+
+      it "writes packet to correct decom topic" do
+        expect(Topic).to receive(:write_topic).with(
+          "DEFAULT__DECOM__{TARGET}__PKT",
+          hash_including(
+            target_name: 'TARGET',
+            packet_name: 'PKT',
+            received_count: 5,
+            stored: 'false'
+          ),
+          nil,
+          db_shard: 0
+        )
+        TelemetryDecomTopic.write_packet(packet, scope: 'DEFAULT')
+      end
+
+      it "includes extra field when packet.extra is set" do
+        packet.extra = { 'foo' => 'bar', 'count' => 42 }
+        expect(Topic).to receive(:write_topic) do |_topic, msg_hash, _id, _opts|
+          expect(msg_hash[:extra]).to eq(JSON.generate({ 'foo' => 'bar', 'count' => 42 }))
+        end
+        TelemetryDecomTopic.write_packet(packet, scope: 'DEFAULT')
+      end
+
+      it "omits extra field when packet.extra is nil" do
+        packet.extra = nil
+        expect(Topic).to receive(:write_topic) do |_topic, msg_hash, _id, _opts|
+          expect(msg_hash).not_to have_key(:extra)
+        end
+        TelemetryDecomTopic.write_packet(packet, scope: 'DEFAULT')
+      end
+
+      it "updates CVT when packet is not stored" do
+        packet.stored = false
+        expect(CvtModel).to receive(:set_json).with(
+          kind_of(String), kind_of(Hash),
+          target_name: 'TARGET', packet_name: 'PKT', scope: 'DEFAULT'
+        )
+        TelemetryDecomTopic.write_packet(packet, scope: 'DEFAULT')
+      end
+
+      it "skips CVT update when packet is stored" do
+        packet.stored = true
+        expect(CvtModel).not_to receive(:set_json)
+        TelemetryDecomTopic.write_packet(packet, scope: 'DEFAULT')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `extra` data to `msg_hash` in `telemetry_decom_topic` and `command_topic`

Resolves https://github.com/OpenC3/cosmos/issues/3335