### PR TITLE
Add token to cleanup-ghcr.yml

### DIFF
--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -29,3 +29,4 @@ jobs:
           # backlog from growing unbounded.
           keep-n-tagged: 50
           delete-untagged: true
+          token: ${{ secrets.CLEANUP_GHCR_TOKEN }}


### PR DESCRIPTION
According to the [docs](https://github.com/dataaxiom/ghcr-cleanup-action#personal-access-tokens-pats) you need a PAT to use `expand-packages: true`. I already added the `CLEANUP_GHCR_TOKEN` to the org secrets.