### PR TITLE
Prompt when hitting `esc` before closing modals with dirty Ace editor

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/EditScreenDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/EditScreenDialog.vue
@@ -177,8 +177,7 @@ export default {
             this.$emit('cancel')
           })
           .catch(() => {
-            // Catch the exception so it doesn't log
-            // but do nothing
+            this.$refs.screenEditor?.editor?.focus()
           })
       } else {
         this.$emit('cancel')

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/EditScreenDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/EditScreenDialog.vue
@@ -17,7 +17,7 @@
     v-model="show"
     persistent
     width="75vw"
-    @keydown.esc="$emit('cancel')"
+    @keydown.esc.stop="handleEsc"
   >
     <v-card>
       <v-toolbar height="24">
@@ -105,6 +105,7 @@ export default {
   data() {
     return {
       editorContent: this.definition,
+      editorIsDirty: false,
     }
   },
   computed: {
@@ -140,6 +141,9 @@ export default {
     },
   },
   watch: {
+    editorContent() {
+      this.editorIsDirty = true
+    },
     definition(newValue) {
       this.editorContent = newValue
     },
@@ -154,6 +158,31 @@ export default {
         .then((dialog) => {
           this.$emit('delete')
         })
+        .catch(() => {
+          // Catch the exception so it doesn't log
+          // but do nothing
+        })
+    },
+    handleEsc: function () {
+      if (this.editorIsDirty) {
+        this.$dialog
+          .confirm(
+            'You have unsaved changes. Are you sure you want to close?',
+            {
+              okText: 'Close without saving',
+              cancelText: 'Cancel',
+            },
+          )
+          .then(() => {
+            this.$emit('cancel')
+          })
+          .catch(() => {
+            // Catch the exception so it doesn't log
+            // but do nothing
+          })
+      } else {
+        this.$emit('cancel')
+      }
     },
   },
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/PluginDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/PluginDialog.vue
@@ -474,8 +474,7 @@ export default {
             this.close()
           })
           .catch(() => {
-            // Catch the exception so it doesn't log
-            // but do nothing
+            this.editor?.focus()
           })
       }
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/PluginDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/PluginDialog.vue
@@ -16,7 +16,12 @@
 -->
 
 <template>
-  <v-dialog v-model="show" persistent width="80vw" @keydown.esc="close">
+  <v-dialog
+    v-model="show"
+    persistent
+    width="80vw"
+    @keydown.esc.stop="handleEsc"
+  >
     <v-card>
       <v-card-title>{{ pluginName }}</v-card-title>
       <v-card-text class="pt-0">
@@ -280,6 +285,7 @@ export default {
       this.editor.setValue(this.localPluginTxt)
       this.editor.clearSelection()
       AceEditorUtils.applyVimModeIfEnabled(this.editor)
+      this.editor.session.$undoManager.markClean() // because setting the initial content made it "dirty"
       this.editor.focus()
     } else {
       this.tab = 1 // Show the diff right off the bat
@@ -450,6 +456,28 @@ export default {
     },
     close: function () {
       this.show = !this.show
+    },
+    handleEsc: function () {
+      const isClean = this.editor.session.$undoManager.isClean()
+      if (isClean) {
+        this.close()
+      } else {
+        this.$dialog
+          .confirm(
+            'You have unsaved changes. Are you sure you want to close?',
+            {
+              okText: 'Close without saving',
+              cancelText: 'Cancel',
+            },
+          )
+          .then(() => {
+            this.close()
+          })
+          .catch(() => {
+            // Catch the exception so it doesn't log
+            // but do nothing
+          })
+      }
     },
     showContextMenu: function (event) {
       this.menuX = event.pageX

--- a/playwright/tests/admin/plugins.p.spec.ts
+++ b/playwright/tests/admin/plugins.p.spec.ts
@@ -231,6 +231,70 @@ test('shows targets associated with plugins', async ({ page, utils }) => {
   ).toContainText('TEMPLATED')
 })
 
+test('prompts before closing dirty plugin editor on ESC', async ({
+  page,
+  utils,
+}) => {
+  const plugin = 'openc3-cosmos-demo'
+  // Open the edit dialog for the demo plugin
+  await page
+    .locator('[data-test=plugin-list-item]')
+    .filter({ hasText: plugin })
+    .locator('[data-test=plugin-actions]')
+    .click()
+  await page.locator('[data-test=edit-plugin]').click()
+  await expect(page.locator('.v-dialog:has-text("Variables")')).toBeVisible()
+
+  // Switch to the plugin.txt tab where the Ace editor is
+  await page.getByRole('tab', { name: 'plugin.txt' }).click()
+  await utils.sleep(500)
+
+  // Press ESC without making changes - dialog should close immediately
+  await page.keyboard.press('Escape')
+  await expect(
+    page.locator('.v-dialog:has-text("Variables")'),
+  ).not.toBeVisible()
+
+  // Reopen the edit dialog
+  await page
+    .locator('[data-test=plugin-list-item]')
+    .filter({ hasText: plugin })
+    .locator('[data-test=plugin-actions]')
+    .click()
+  await page.locator('[data-test=edit-plugin]').click()
+  await expect(page.locator('.v-dialog:has-text("Variables")')).toBeVisible()
+
+  // Switch to the plugin.txt tab
+  await page.getByRole('tab', { name: 'plugin.txt' }).click()
+  await utils.sleep(500)
+
+  // Type something into the Ace editor to make it dirty
+  await page.locator('.v-dialog .editor textarea').first().fill('# dirty edit')
+  await utils.sleep(500)
+
+  // Press ESC - should show the unsaved changes confirmation dialog
+  await page.keyboard.press('Escape')
+  await expect(page.getByText('You have unsaved changes')).toBeVisible()
+
+  // Click Cancel to stay in the editor
+  await page.locator('[data-test="confirm-dialog-cancel"]').click()
+  // The plugin dialog should still be open
+  await expect(page.locator('.v-dialog:has-text("Variables")')).toBeVisible()
+
+  // Press ESC again to re-trigger the confirmation
+  await page.keyboard.press('Escape')
+  await expect(page.getByText('You have unsaved changes')).toBeVisible()
+
+  // This time confirm closing without saving
+  await page
+    .locator('[data-test="confirm-dialog-close without saving"]')
+    .click()
+  // The plugin dialog should now be closed
+  await expect(
+    page.locator('.v-dialog:has-text("Variables")'),
+  ).not.toBeVisible()
+})
+
 // Playwright requires a separate test.describe to then call test.use
 test.describe(() => {
   // Must be the operator to modify files

--- a/playwright/tests/tlm-viewer.p.spec.ts
+++ b/playwright/tests/tlm-viewer.p.spec.ts
@@ -392,6 +392,65 @@ test('plays back to a screen', async ({ page, utils }) => {
     .toBe(previousTime + 15)
 })
 
+test('prompts before closing dirty edit screen on ESC', async ({
+  page,
+  utils,
+}) => {
+  await showScreen(page, utils, 'INST', 'ADCS', true, async function () {
+    // Open the edit screen dialog
+    await page.locator('[data-test=edit-screen-icon]').click()
+    await expect(
+      page.locator('.v-toolbar:has-text("Edit Screen")'),
+    ).toBeVisible()
+
+    // Press ESC without making changes - dialog should close immediately
+    await page.keyboard.press('Escape')
+    await expect(
+      page.locator('.v-toolbar:has-text("Edit Screen")'),
+    ).not.toBeVisible()
+
+    // Reopen the edit screen dialog
+    await page.locator('[data-test=edit-screen-icon]').click()
+    await expect(
+      page.locator('.v-toolbar:has-text("Edit Screen")'),
+    ).toBeVisible()
+
+    // Type something into the Ace editor to make it dirty
+    await page.locator('textarea').first().fill('SCREEN AUTO AUTO 0.5\nLABEL DIRTY_CHANGE')
+    await utils.sleep(500)
+
+    // Press ESC - should show the unsaved changes confirmation dialog
+    await page.keyboard.press('Escape')
+    await expect(
+      page.getByText('You have unsaved changes'),
+    ).toBeVisible()
+
+    // Click Cancel to stay in the editor
+    await page
+      .locator('[data-test="confirm-dialog-cancel"]')
+      .click()
+    // The edit dialog should still be open
+    await expect(
+      page.locator('.v-toolbar:has-text("Edit Screen")'),
+    ).toBeVisible()
+
+    // Press ESC again to re-trigger the confirmation
+    await page.keyboard.press('Escape')
+    await expect(
+      page.getByText('You have unsaved changes'),
+    ).toBeVisible()
+
+    // This time confirm closing without saving
+    await page
+      .locator('[data-test="confirm-dialog-close without saving"]')
+      .click()
+    // The edit dialog should now be closed
+    await expect(
+      page.locator('.v-toolbar:has-text("Edit Screen")'),
+    ).not.toBeVisible()
+  })
+})
+
 test('links array item to TlmGrapher', async ({ page, utils }) => {
   await showScreen(page, utils, 'INST', 'ARRAY', true, async function () {
     // Right-click the ARY[0] value widget to open the context menu


### PR DESCRIPTION
closes #3237

Three instances of Ace editor in `esc`-able modals:
- **ScreenEditor.vue (edit a screen in TlmViewer):** This is used in EditScreenDialog.vue, but the editor and modal are in different components, so it was easier to just manually track dirty state in the parent component.
- **PluginDialog.vue (edit plugin.txt in Admin Console):** Fixed here by checking `isClean()`. This means undo state is respected (i.e. change > undo > `esc` does not prompt you about the input being dirty).
- **OutputDialog.vue:** Editor is read-only. Not relevant.