### PR TITLE
feat(scriptrunner): add default_path and filter to open_bucket_dialog

### DIFF
--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -488,7 +488,7 @@ print(file.filename) # The name of the selected file
 print(file.read())
 file.close()
 
-# Pre-select the procedures folder and restrict to Python files
+# Preselect the procedures folder and restrict to Python files
 file = open_bucket_dialog(
     "Select a Procedure",
     "Choose a procedure",
@@ -510,7 +510,7 @@ puts file.filename # The name of the selected file
 puts file.read
 file.delete
 
-# Pre-select the procedures folder and restrict to Ruby files
+# Preselect the procedures folder and restrict to Ruby files
 file = open_bucket_dialog(
   "Select a Procedure",
   "Choose a procedure",

--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -458,7 +458,7 @@ The open_bucket_dialog method creates a dialog box that allows the user to brows
 <TabItem value="python" label="Python Syntax">
 
 ```python
-open_bucket_dialog("<Title>", "<Message>")
+open_bucket_dialog("<Title>", "<Message>", default_path=<default_path>, filter=<filter>)
 ```
 
 </TabItem>
@@ -466,16 +466,18 @@ open_bucket_dialog("<Title>", "<Message>")
 <TabItem value="ruby" label="Ruby Syntax">
 
 ```ruby
-open_bucket_dialog("<Title>", "<Message>")
+open_bucket_dialog("<Title>", "<Message>", default_path: <default_path>, filter: <filter>)
 ```
 
 </TabItem>
 </Tabs>
 
-| Parameter | Description                                                   |
-| --------- | ------------------------------------------------------------- |
-| Title     | The title to put on the dialog. Required.                     |
-| Message   | The message to display in the dialog box. Optional parameter. |
+| Parameter                                                            | Description                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Title                                                                | The title to put on the dialog. Required.                                                                                                                                                                                                                                                                                             |
+| Message                                                              | The message to display in the dialog box. Optional parameter.                                                                                                                                                                                                                                                                         |
+| default_path <span class="badge badge--secondary">Since 7.1.1</span> | Path to preselect inside the dialog in the form `bucket/path/to/file.ext` (or `bucket/path/to/folder/` for a folder with a trailing slash `/`). The user can still navigate elsewhere. Path traversal segments (`..`) are rejected. Per-scope bucket permissions are still enforced server-side. Optional parameter, defaults to nil. |
+| filter <span class="badge badge--secondary">Since 7.1.1</span>       | Comma-separated list of file suffixes used to restrict the listing (e.g. `".txt"` or `".txt,.json"`). Folders are always shown so the user can navigate. Optional parameter, defaults to nil.                                                                                                                                         |
 
 <Tabs groupId="script-language">
 <TabItem value="python" label="Python Example">
@@ -484,6 +486,17 @@ open_bucket_dialog("<Title>", "<Message>")
 file = open_bucket_dialog("Select a File", "Choose a file from a bucket")
 print(file.filename) # The name of the selected file
 print(file.read())
+file.close()
+
+# Pre-select the procedures folder and restrict to Python files
+file = open_bucket_dialog(
+    "Select a Procedure",
+    "Choose a procedure",
+    # trailing slash indicates folder, otherwise assumes a file
+    default_path="config/DEFAULT/targets/INST2/procedures/",
+    filter=".py",
+)
+print(file.filename)
 file.close()
 ```
 
@@ -495,6 +508,17 @@ file.close()
 file = open_bucket_dialog("Select a File", "Choose a file from a bucket")
 puts file.filename # The name of the selected file
 puts file.read
+file.delete
+
+# Pre-select the procedures folder and restrict to Ruby files
+file = open_bucket_dialog(
+  "Select a Procedure",
+  "Choose a procedure",
+  # trailing slash indicates folder, otherwise assumes a file
+  default_path: "config/DEFAULT/targets/INST/procedures/",
+  filter: ".rb"
+)
+puts file.filename
 file.delete
 ```
 

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/procedures/file_dialog.rb
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/procedures/file_dialog.rb
@@ -21,3 +21,14 @@ puts file.path # Path of the tempfile (generally not used)
 puts file.filename # Filename that was selected in the dialog
 puts file.read
 file.delete
+
+# Pre-select the procedures folder and restrict to .rb files.
+# default_path uses the form bucket/path - trailing slash means folder.
+file = open_bucket_dialog(
+  "Pick a procedure",
+  "Defaults to INST procedures, .rb only",
+  default_path: "config/DEFAULT/targets/INST/procedures/",
+  filter: ".rb"
+)
+puts file.filename
+file.delete

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/procedures/file_dialog.rb
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/procedures/file_dialog.rb
@@ -22,7 +22,7 @@ puts file.filename # Filename that was selected in the dialog
 puts file.read
 file.delete
 
-# Pre-select the procedures folder and restrict to .rb files.
+# Preselect the procedures folder and restrict to .rb files.
 # default_path uses the form bucket/path - trailing slash means folder.
 file = open_bucket_dialog(
   "Pick a procedure",

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/procedures/file_dialog.py
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/procedures/file_dialog.py
@@ -25,7 +25,7 @@ print(file.filename())  # Filename that was selected in the dialog
 print(file.read())
 file.close()
 
-# Pre-select the procedures folder and restrict to .py files.
+# Preselect the procedures folder and restrict to .py files.
 # default_path uses the form bucket/path - trailing slash means folder.
 file = open_bucket_dialog(
     "Pick a procedure",

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/procedures/file_dialog.py
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/procedures/file_dialog.py
@@ -24,3 +24,14 @@ print(file)  # Python tempfile.NamedTemporaryFile object
 print(file.filename())  # Filename that was selected in the dialog
 print(file.read())
 file.close()
+
+# Pre-select the procedures folder and restrict to .py files.
+# default_path uses the form bucket/path - trailing slash means folder.
+file = open_bucket_dialog(
+    "Pick a procedure",
+    "Defaults to INST2 procedures, .py only",
+    default_path="config/DEFAULT/targets/INST2/procedures/",
+    filter=".py",
+)
+print(file.filename())
+file.close()

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/BucketDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/BucketDialog.vue
@@ -243,7 +243,7 @@ export default {
       if (parts.length === 0) return
       // Block `..` traversal segments. A literal `.` is harmless but stripped.
       // Silently ignore an invalid default_path - the user can still browse manually.
-      if (parts.some((p) => p === '..')) {
+      if (parts.includes('..')) {
         return
       }
       const cleanParts = parts.filter((p) => p !== '.')

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/BucketDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/BucketDialog.vue
@@ -159,6 +159,14 @@ export default {
       type: String,
       default: null,
     },
+    defaultPath: {
+      type: String,
+      default: null,
+    },
+    filter: {
+      type: String,
+      default: null,
+    },
     modelValue: Boolean,
   },
   emits: ['update:modelValue', 'response'],
@@ -171,6 +179,9 @@ export default {
       selectedFile: null,
       search: '',
       loading: false,
+      // Used to track a file to preselect after loading a new folder.
+      // This is needed to support the defaultPath prop which may specify a file to preselect.
+      pendingPreselect: null,
     }
   },
   computed: {
@@ -191,14 +202,31 @@ export default {
       }))
     },
     filteredFiles() {
-      if (!this.search) return this.files
+      let files = this.files
+      if (this.filter) {
+        // Match the open_file_dialog filter behavior - suffix match on file name.
+        // Folders are always shown so users can navigate into them.
+        const filters = this.filter
+          .split(',')
+          .map((f) => f.trim().toLowerCase())
+          .filter((f) => !!f)
+        if (filters.length > 0) {
+          files = files.filter(
+            (f) =>
+              f.icon === 'mdi-folder' ||
+              filters.some((suffix) => f.name.toLowerCase().endsWith(suffix)),
+          )
+        }
+      }
+      if (!this.search) return files
       const term = this.search.toLowerCase()
-      return this.files.filter((f) => f.name.toLowerCase().includes(term))
+      return files.filter((f) => f.name.toLowerCase().includes(term))
     },
   },
   created() {
     Api.get('/openc3-api/storage/buckets').then((response) => {
       this.buckets = response.data
+      this.applyDefaultPath()
     })
   },
   methods: {
@@ -207,10 +235,42 @@ export default {
       if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
       return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
     },
+    applyDefaultPath() {
+      if (!this.defaultPath) return
+      // Strip leading slashes then split.
+      const raw = this.defaultPath.replace(/^\/+/, '')
+      const parts = raw.split('/').filter((p) => !!p)
+      if (parts.length === 0) return
+      // Block `..` traversal segments. A literal `.` is harmless but stripped.
+      // Silently ignore an invalid default_path - the user can still browse manually.
+      if (parts.some((p) => p === '..')) {
+        return
+      }
+      const cleanParts = parts.filter((p) => p !== '.')
+      const bucketName = cleanParts.shift().toLowerCase()
+      const match = this.buckets.find((b) => b.toLowerCase() === bucketName)
+      if (!match) {
+        return
+      }
+      this.selectedBucket = match
+      const endsWithSlash =
+        cleanParts.length > 0 && this.defaultPath.endsWith('/')
+      let preselect = null
+      let folderParts = cleanParts
+      if (cleanParts.length > 0 && !endsWithSlash) {
+        // Treat the last segment as a potential filename to preselect.
+        preselect = cleanParts[cleanParts.length - 1]
+        folderParts = cleanParts.slice(0, -1)
+      }
+      this.path = folderParts.length > 0 ? folderParts.join('/') + '/' : ''
+      this.pendingPreselect = preselect
+      this.updateFiles()
+    },
     selectBucket(bucket) {
       this.selectedBucket = bucket
       this.path = ''
       this.selectedFile = null
+      this.pendingPreselect = null
       this.updateFiles()
     },
     backArrow() {
@@ -260,10 +320,21 @@ export default {
             })),
           )
           this.loading = false
+          if (this.pendingPreselect) {
+            const target = this.pendingPreselect
+            this.pendingPreselect = null
+            const hit = this.files.find(
+              (f) => f.name === target && f.icon === 'mdi-file',
+            )
+            if (hit) {
+              this.selectedFile = target
+            }
+          }
         })
         .catch(() => {
           this.files = []
           this.loading = false
+          this.pendingPreselect = null
         })
     },
     submitHandler() {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -561,6 +561,8 @@
     v-model="bucket.show"
     :title="bucket.title"
     :message="bucket.message"
+    :default-path="bucket.defaultPath"
+    :filter="bucket.filter"
     @response="bucketDialogCallback"
   />
   <information-dialog
@@ -865,6 +867,8 @@ export default {
         show: false,
         title: '',
         message: '',
+        defaultPath: null,
+        filter: null,
       },
       prompt: {
         show: false,
@@ -2419,6 +2423,9 @@ export default {
         case 'open_bucket_dialog':
           this.bucket.title = data.args[0]
           this.bucket.message = data.args[1]
+          this.bucket.defaultPath =
+            (data.kwargs && data.kwargs.default_path) || null
+          this.bucket.filter = (data.kwargs && data.kwargs.filter) || null
           this.bucket.show = true
           break
         // This is called continuously by the backend

--- a/openc3/lib/openc3/script/script.rb
+++ b/openc3/lib/openc3/script/script.rb
@@ -206,10 +206,12 @@ module OpenC3
       _file_dialog(title, message, filter)
     end
 
-    def open_bucket_dialog(title, message = "Open Bucket File")
+    def open_bucket_dialog(title, message = "Open Bucket File", default_path: nil, filter: nil)
       answer = ''
+      hint = default_path ? " [default: #{default_path}]" : ''
+      hint += " filter: #{filter}" if filter
       while answer.empty?
-        print "#{title}\n#{message}\n<Type bucket file path (e.g. BUCKET/path/to/file)>:"
+        print "#{title}\n#{message}\n<Type bucket file path (e.g. BUCKET/path/to/file)>#{hint}:"
         answer = gets
         answer.chomp!
       end

--- a/openc3/python/openc3/script/__init__.py
+++ b/openc3/python/openc3/script/__init__.py
@@ -116,10 +116,13 @@ def open_files_dialog(title, message="Open File", filter=None):
     _file_dialog(title, message, filter)
 
 
-def open_bucket_dialog(title, message="Open Bucket File"):
+def open_bucket_dialog(title, message="Open Bucket File", default_path=None, filter=None):
     answer = ""
+    hint = f" [default: {default_path}]" if default_path else ""
+    if filter:
+        hint += f" filter: {filter}"
     while len(answer) == 0:
-        print(f"{title}\n{message}\n<Type bucket file path (e.g. BUCKET/path/to/file)>:")
+        print(f"{title}\n{message}\n<Type bucket file path (e.g. BUCKET/path/to/file)>{hint}:")
         answer = input()
     return answer
 

--- a/openc3/python/test/script/test_dialogs.py
+++ b/openc3/python/test/script/test_dialogs.py
@@ -1,0 +1,44 @@
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from openc3.script import open_bucket_dialog
+
+
+class TestOpenBucketDialog(unittest.TestCase):
+    def test_returns_user_input(self):
+        with patch("builtins.input", return_value="config/foo.txt"), redirect_stdout(io.StringIO()):
+            self.assertEqual(
+                open_bucket_dialog("Title"), "config/foo.txt"
+            )
+
+    def test_accepts_default_path_and_filter_kwargs(self):
+        buf = io.StringIO()
+        with patch("builtins.input", return_value="config/foo.txt"), redirect_stdout(buf):
+            result = open_bucket_dialog(
+                "Title",
+                "Msg",
+                default_path="config/DEFAULT/targets/INST2/procedures/",
+                filter=".py",
+            )
+        self.assertEqual(result, "config/foo.txt")
+        output = buf.getvalue()
+        # Hint text should mention both kwargs to the user.
+        self.assertIn("config/DEFAULT/targets/INST2/procedures/", output)
+        self.assertIn(".py", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openc3/spec/script/script_dialog_spec.rb
+++ b/openc3/spec/script/script_dialog_spec.rb
@@ -1,0 +1,44 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+require 'spec_helper'
+require 'openc3/script'
+
+module OpenC3
+  describe Script do
+    describe "open_bucket_dialog stub" do
+      include OpenC3::Script
+
+      it "accepts no kwargs and returns user input" do
+        allow(self).to receive(:print)
+        allow(self).to receive(:gets).and_return("config/foo.txt\n")
+        expect(open_bucket_dialog("Title")).to eql "config/foo.txt"
+      end
+
+      it "accepts default_path and filter kwargs" do
+        captured = nil
+        allow(self).to receive(:print) { |arg| captured = arg }
+        allow(self).to receive(:gets).and_return("config/foo.txt\n")
+        result = open_bucket_dialog(
+          "Title", "Msg",
+          default_path: "config/DEFAULT/targets/INST/procedures/",
+          filter: ".rb",
+        )
+        expect(result).to eql "config/foo.txt"
+        # Hint text should surface both kwargs to the user.
+        expect(captured).to include "config/DEFAULT/targets/INST/procedures/"
+        expect(captured).to include ".rb"
+      end
+    end
+  end
+end

--- a/playwright/tests/script-runner/prompts.p.spec.ts
+++ b/playwright/tests/script-runner/prompts.p.spec.ts
@@ -410,6 +410,15 @@ async function runScript(page, utils, filename) {
   await page.getByText('target.txt').click()
   await page.locator('[data-test="bucket-ok"]').click()
 
+  await expect(page.locator('.v-dialog')).toBeVisible()
+  await expect(page.locator('.v-dialog')).toContainText('Pick a procedure')
+  if (filename.endsWith('.rb')) {
+    await page.getByText('checks.rb').click()
+  } else {
+    await page.getByText('checks.py').click()
+  }
+  await page.locator('[data-test="bucket-ok"]').click()
+
   await expect(page.locator('[data-test=state] input')).toHaveValue('completed')
   await expect(page.locator('[data-test=output-messages]')).toContainText(
     /File\(s\): \[['"].prettierrc.js['"]\]/,


### PR DESCRIPTION
Adds two optional kwargs so scripts can preselect a starting bucket/path and restrict the listing to specific file suffixes. Path traversal (..) segments are rejected client-side; server-side scope RBAC on the storage files endpoint continues to gate access.

closes #3234
closes #3233