### PR TITLE
Only display screens from installed targets

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/models/screen.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/screen.rb
@@ -16,16 +16,22 @@
 # if purchased from OpenC3, Inc.
 
 require 'openc3/utilities/target_file'
+require 'openc3/models/target_model'
 
 class Screen < OpenC3::TargetFile
   def self.all(scope)
     result = super(scope, ['screens'])
+    # Only list screens belonging to currently installed targets. Modified
+    # screens for uninstalled targets remain in storage so they're restored
+    # if the target is reinstalled, but they aren't displayed in TlmViewer.
+    installed_targets = OpenC3::TargetModel.names(scope: scope)
     screens = []
     result.each do |path|
       filename = path.split('*')[0] # Don't differentiate modified - TODO: Should we?
-      split_filename = filename.split('/')
       next unless File.extname(filename) == ".txt"
       next if File.basename(filename, ".txt")[0] == '_' # underscore filenames are partials
+      target = filename.split('/')[0]
+      next unless installed_targets.include?(target)
       screens << filename
     end
     screens

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/screens_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/screens_controller_spec.rb
@@ -58,16 +58,39 @@ RSpec.describe ScreensController, :type => :controller do
 
   describe "index" do
     it "lists all screens for a target" do
-      class Screen < OpenC3::TargetFile
-        def self.all(scope)
-          # Override Screen.all to return a fake list of files
-          ['INST/screens/screen1.txt','INST/screens/screen2.txt']
-        end
-      end
+      allow(OpenC3::TargetModel).to receive(:names).with(scope: 'DEFAULT').and_return(['INST'])
+      allow(OpenC3::TargetFile).to receive(:all).and_return(
+        ['INST/screens/screen1.txt', 'INST/screens/screen2.txt']
+      )
       get :index, params: { scope: 'DEFAULT' }
       expect(response).to have_http_status(:ok)
       ret = JSON.parse(response.body, allow_nan: true, create_additions: true)
       expect(ret).to eql(['INST/screens/screen1.txt', 'INST/screens/screen2.txt'])
+    end
+
+    it "filters out screens from uninstalled targets" do
+      allow(OpenC3::TargetModel).to receive(:names).with(scope: 'DEFAULT').and_return(['INST'])
+      # INST is installed (with a modified screen marked '*') but OLD is uninstalled
+      # with orphaned modified files still present in the bucket.
+      allow(OpenC3::TargetFile).to receive(:all).and_return(
+        ['INST/screens/screen1.txt', 'INST/screens/screen2.txt*',
+         'OLD/screens/orphan.txt', 'OLD/screens/orphan2.txt*']
+      )
+      get :index, params: { scope: 'DEFAULT' }
+      expect(response).to have_http_status(:ok)
+      ret = JSON.parse(response.body, allow_nan: true, create_additions: true)
+      expect(ret).to eql(['INST/screens/screen1.txt', 'INST/screens/screen2.txt'])
+    end
+
+    it "ignores partial screen files starting with underscore" do
+      allow(OpenC3::TargetModel).to receive(:names).with(scope: 'DEFAULT').and_return(['INST'])
+      allow(OpenC3::TargetFile).to receive(:all).and_return(
+        ['INST/screens/screen1.txt', 'INST/screens/_partial.txt']
+      )
+      get :index, params: { scope: 'DEFAULT' }
+      expect(response).to have_http_status(:ok)
+      ret = JSON.parse(response.body, allow_nan: true, create_additions: true)
+      expect(ret).to eql(['INST/screens/screen1.txt'])
     end
   end
 


### PR DESCRIPTION
Tested by installing FakeSat. Modify the STATUS screen. Delete the plugin but do NOT delete the modified files. Go back to Tlm Viewer and the FAKESAT target no longer shows up. Reinstall FakeSat and observe the modified screen.

closes #2723

