### PR TITLE
Fix: Support displaying newline characters in telemetry string values

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/FormatValueBase.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/FormatValueBase.js
@@ -37,7 +37,14 @@ export default {
       if (value === null || value === undefined) {
         return 'null'
       }
-      return String(value)
+      const str = String(value)
+      // Escape special whitespace so they display visibly in single-line widgets.
+      // Widgets that support multi-line display (e.g. TextboxWidget) set
+      // escapeSpecialCharacters: false in their data() to opt out.
+      if (this.escapeSpecialCharacters !== false) {
+        return str.replace(/\r\n/g, '\\r\\n').replace(/\r/g, '\\r').replace(/\n/g, '\\n').replace(/\t/g, '\\t')
+      }
+      return str
     },
     // sprintf-js doesn't support BigInt values so we handle common
     // integer format specifiers manually to preserve full precision

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/TextboxWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/TextboxWidget.vue
@@ -66,6 +66,8 @@ export default {
     return {
       width: 200,
       height: 200,
+      // Allow actual newlines to render as line breaks in v-textarea
+      escapeSpecialCharacters: false,
     }
   },
   computed: {


### PR DESCRIPTION
## Summary

Telemetry string values containing newline (and other special whitespace) characters were silently truncated in the packet viewer and other single-line displays. In TEXTBOX screen widgets, newlines weren't rendered as actual line breaks.

## Changes

### `FormatValueBase.js`
- In `formatValueBase()`, when returning a plain string value, escape special whitespace characters:
  - `\n` → `\n` (visible escape sequence)  
  - `\r` → `\r`
  - `\t` → `\t`
  - `\r\n` → `\r\n`
- Widgets can opt out by setting `escapeSpecialCharacters: false` in their `data()`.

### `TextboxWidget.vue`
- Sets `escapeSpecialCharacters: false` so actual newline characters in telemetry values are preserved and rendered as real line breaks inside the `v-textarea`.

## Testing

- A telemetry string value like `"line1\nline2"` now shows as `line1\nline2` in the packet viewer (escaped, no truncation).
- The same value in a TEXTBOX widget renders with `line2` on its own line below `line1`.

Fixes #154