### PR TITLE
Feat: CmdSender file uploads — Send Raw File and Upload Data for BLOCK parameters

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
@@ -265,18 +265,17 @@ export default {
   computed: {
     menus: function () {
       return [
-        // TODO: Implement send raw
-        // {
-        //   label: 'File',
-        //   items: [
-        //     {
-        //       label: 'Send Raw',
-        //       command: () => {
-        //         this.setupRawCmd()
-        //       },
-        //     },
-        //   ],
-        // },
+        {
+          label: 'File',
+          items: [
+            {
+              label: 'Send Raw File',
+              command: () => {
+                this.setupRawCmd()
+              },
+            },
+          ],
+        },
         {
           label: 'Mode',
           items: [
@@ -863,71 +862,63 @@ export default {
       })
     },
 
-    // setupRawCmd() {
-    //   this.api.get_interface_names().then(
-    //     (response) => {
-    //       let interfaces = []
-    //       for (let i = 0; i < response.length; i++) {
-    //         interfaces.push({ label: response[i], value: response[i] })
-    //       }
-    //       this.interfaces = interfaces
-    //       this.selectedInterface = interfaces[0].value
-    //       this.displaySendRaw = true
-    //     },
-    //     (error) => {
-    //       this.displaySendRaw = false
-    //       this.displayError('getting interface names', error, true)
-    //     }
-    //   )
-    // },
+    setupRawCmd() {
+      this.api.get_interface_names().then(
+        (response) => {
+          let interfaces = []
+          for (let i = 0; i < response.length; i++) {
+            interfaces.push({ label: response[i], value: response[i] })
+          }
+          this.interfaces = interfaces
+          this.selectedInterface = interfaces[0].value
+          this.displaySendRaw = true
+        },
+        (error) => {
+          this.displaySendRaw = false
+          this.displayError('getting interface names', error, true)
+        },
+      )
+    },
 
-    // selectRawCmdFile(event) {
-    //   this.rawCmdFile = event.target.files[0]
-    // },
+    selectRawCmdFile(event) {
+      this.rawCmdFile = event.target.files[0]
+    },
 
-    // onLoad(event) {
-    //   let bufView = new Uint8Array(event.target.result)
-    //   let jstr = { json_class: 'String', raw: [] }
-    //   for (let i = 0; i < bufView.length; i++) {
-    //     jstr.raw.push(bufView[i])
-    //   }
+    onLoad(event) {
+      let bufView = new Uint8Array(event.target.result)
+      let jstr = { json_class: 'String', raw: [] }
+      for (let i = 0; i < bufView.length; i++) {
+        jstr.raw.push(bufView[i])
+      }
+      this.api.send_raw(this.selectedInterface, jstr).then(
+        () => {
+          this.displaySendRaw = false
+          this.status =
+            'Sent ' +
+            bufView.length +
+            ' bytes to interface ' +
+            this.selectedInterface
+        },
+        (error) => {
+          this.displaySendRaw = false
+          this.displayError('sending raw data', error, true)
+        },
+      )
+    },
 
-    //   this.api.send_raw(this.selectedInterface, jstr).then(
-    //     () => {
-    //       this.displaySendRaw = false
-    //       this.status =
-    //         'Sent ' +
-    //         bufView.length +
-    //         ' bytes to interface ' +
-    //         this.selectedInterface
-    //     },
-    //     (error) => {
-    //       this.displaySendRaw = false
-    //       this.displayError('sending raw data', error, true)
-    //     }
-    //   )
-    // },
-
-    // sendRawCmd() {
-    //   let self = this
-    //   let reader = new FileReader()
-    //   reader.onload = function (e) {
-    //     self.onLoad(e)
-    //   }
-    //   reader.onerror = function (e) {
-    //     self.displaySendRaw = false
-    //     let target = e.target
-    //     self.displayError('sending raw data', target.error, true)
-    //   }
-    //   // TBD - use the other event handlers to implement a progress bar for the
-    //   // file upload.  Handle abort as well?
-    //   //reader.onloadstart = function(e) {}
-    //   //reader.onprogress = function(e) {}
-    //   //reader.onloadend = function(e) {}
-    //   //reader.onabort = function(e) {}
-
-    //   reader.readAsArrayBuffer(this.rawCmdFile)
-    // },
+    sendRawCmd() {
+      let self = this
+      let reader = new FileReader()
+      reader.onload = function (e) {
+        self.onLoad(e)
+      }
+      reader.onerror = function (e) {
+        self.displaySendRaw = false
+        let target = e.target
+        self.displayError('sending raw data', target.error, true)
+      }
+      reader.readAsArrayBuffer(this.rawCmdFile)
+    },
 
     cancelRawCmd() {
       this.displaySendRaw = false

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CommandEditor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CommandEditor.vue
@@ -87,6 +87,14 @@
       </v-list>
     </v-menu>
 
+    <!-- Hidden file input for BLOCK parameter upload -->
+    <input
+      ref="blockFileInput"
+      type="file"
+      style="display: none"
+      @change="onBlockFileSelected($event)"
+    />
+
     <details-dialog
       v-model="viewDetails"
       :target-name="targetName"
@@ -182,10 +190,18 @@ export default {
       contextMenuShown: false,
       viewDetails: false,
       parameterName: '',
+      contextMenuRow: null,
       hazardousParameters: {},
       x: 0,
       y: 0,
-      contextMenuOptions: [
+    }
+  },
+  computed: {
+    hasHazardousParameter() {
+      return Object.values(this.hazardousParameters).some((v) => v === true)
+    },
+    contextMenuOptions() {
+      const options = [
         {
           title: 'Details',
           action: () => {
@@ -193,12 +209,17 @@ export default {
             this.viewDetails = true
           },
         },
-      ],
-    }
-  },
-  computed: {
-    hasHazardousParameter() {
-      return Object.values(this.hazardousParameters).some((v) => v === true)
+      ]
+      if (this.contextMenuRow?.type === 'BLOCK') {
+        options.push({
+          title: 'Upload Data',
+          action: () => {
+            this.contextMenuShown = false
+            this.$refs.blockFileInput.click()
+          },
+        })
+      }
+      return options
     },
   },
   created() {
@@ -232,12 +253,30 @@ export default {
     showContextMenu(event, row) {
       event.preventDefault()
       this.parameterName = row.item.parameter_name
+      this.contextMenuRow = row.item
       this.contextMenuShown = false
       this.x = event.clientX
       this.y = event.clientY
       this.$nextTick(() => {
         this.contextMenuShown = true
       })
+    },
+    onBlockFileSelected(event) {
+      const file = event.target.files[0]
+      if (!file || !this.contextMenuRow) return
+      const reader = new FileReader()
+      reader.onload = (e) => {
+        const bytes = new Uint8Array(e.target.result)
+        // Convert to space-separated hex string so the parameter text field
+        // shows a human-readable representation (e.g. "DE AD BE EF")
+        const hex = Array.from(bytes)
+          .map((b) => b.toString(16).padStart(2, '0').toUpperCase())
+          .join(' ')
+        this.contextMenuRow.val = hex
+        // Reset input so the same file can be re-selected if needed
+        event.target.value = ''
+      }
+      reader.readAsArrayBuffer(file)
     },
     updateCmdParams() {
       this.ignoredParams = []

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/FormatValueBase.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/FormatValueBase.js
@@ -37,7 +37,14 @@ export default {
       if (value === null || value === undefined) {
         return 'null'
       }
-      return String(value)
+      const str = String(value)
+      // Escape special whitespace so they display visibly in single-line widgets.
+      // Widgets that support multi-line display (e.g. TextboxWidget) set
+      // escapeSpecialCharacters: false in their data() to opt out.
+      if (this.escapeSpecialCharacters !== false) {
+        return str.replace(/\r\n/g, '\\r\\n').replace(/\r/g, '\\r').replace(/\n/g, '\\n').replace(/\t/g, '\\t')
+      }
+      return str
     },
     // sprintf-js doesn't support BigInt values so we handle common
     // integer format specifiers manually to preserve full precision

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/TextboxWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/TextboxWidget.vue
@@ -66,6 +66,8 @@ export default {
     return {
       width: 200,
       height: 200,
+      // Allow actual newlines to render as line breaks in v-textarea
+      escapeSpecialCharacters: false,
     }
   },
   computed: {


### PR DESCRIPTION
## Summary

Implements two file-upload features in the Command Sender tool requested in #59.

### 1. Send Raw File (File menu)

A new **File > Send Raw File** menu option allows users to upload a binary file and send its raw bytes to a selected interface via `send_raw()`. The dialog UI and data fields already existed in the codebase; this PR enables the feature by uncommenting and wiring up the supporting methods (`setupRawCmd`, `selectRawCmdFile`, `onLoad`, `sendRawCmd`).

**Flow:** File menu → Send Raw File → select interface from dropdown → pick file → Ok → sends bytes, shows status (e.g. "Sent 256 bytes to interface INST_INT").

### 2. Upload Data (right-click on BLOCK parameter)

Right-clicking a parameter row in the Command Editor now shows an **Upload Data** option when the parameter's `data_type` is `BLOCK`. Selecting it opens a file picker; the file's bytes are read as an `ArrayBuffer` and formatted as a space-separated uppercase hex string (e.g. `"DE AD BE EF"`) that fills the parameter field.

**Flow:** Right-click BLOCK parameter → Upload Data → pick file → hex string populates the field → included in normal command send.

## Files Changed

- `CommandSender.vue` — enable File menu + uncomment raw-send methods
- `CommandEditor.vue` — dynamic context menu (computed) with Upload Data for BLOCK params + hidden file input + `onBlockFileSelected` handler

Fixes #59