### PR TITLE
feat(cmdsender): file upload support for BLOCK params and Send Raw File

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
@@ -176,7 +176,11 @@
             <v-row no-gutters>
               <v-col>Filename:</v-col>
               <v-col>
-                <input type="file" @change="selectRawCmdFile($event)" />
+                <input
+                  type="file"
+                  data-test="send-raw-file"
+                  @change="selectRawCmdFile($event)"
+                />
               </v-col>
             </v-row>
             <v-row>
@@ -265,18 +269,17 @@ export default {
   computed: {
     menus: function () {
       return [
-        // TODO: Implement send raw
-        // {
-        //   label: 'File',
-        //   items: [
-        //     {
-        //       label: 'Send Raw',
-        //       command: () => {
-        //         this.setupRawCmd()
-        //       },
-        //     },
-        //   ],
-        // },
+        {
+          label: 'File',
+          items: [
+            {
+              label: 'Send Raw File',
+              command: () => {
+                this.setupRawCmd()
+              },
+            },
+          ],
+        },
         {
           label: 'Mode',
           items: [
@@ -863,71 +866,81 @@ export default {
       })
     },
 
-    // setupRawCmd() {
-    //   this.api.get_interface_names().then(
-    //     (response) => {
-    //       let interfaces = []
-    //       for (let i = 0; i < response.length; i++) {
-    //         interfaces.push({ label: response[i], value: response[i] })
-    //       }
-    //       this.interfaces = interfaces
-    //       this.selectedInterface = interfaces[0].value
-    //       this.displaySendRaw = true
-    //     },
-    //     (error) => {
-    //       this.displaySendRaw = false
-    //       this.displayError('getting interface names', error, true)
-    //     }
-    //   )
-    // },
+    setupRawCmd() {
+      this.api.get_interface_names().then(
+        (response) => {
+          let interfaces = []
+          for (let i = 0; i < response.length; i++) {
+            interfaces.push({ label: response[i], value: response[i] })
+          }
+          this.interfaces = interfaces
+          this.selectedInterface = interfaces.length ? interfaces[0].value : ''
+          this.rawCmdFile = null
+          this.displaySendRaw = true
+        },
+        (error) => {
+          this.displaySendRaw = false
+          this.displayError('getting interface names', error, true)
+        },
+      )
+    },
 
-    // selectRawCmdFile(event) {
-    //   this.rawCmdFile = event.target.files[0]
-    // },
+    selectRawCmdFile(event) {
+      this.rawCmdFile = event.target.files[0]
+    },
 
-    // onLoad(event) {
-    //   let bufView = new Uint8Array(event.target.result)
-    //   let jstr = { json_class: 'String', raw: [] }
-    //   for (let i = 0; i < bufView.length; i++) {
-    //     jstr.raw.push(bufView[i])
-    //   }
+    onLoad(event) {
+      let bufView = new Uint8Array(event.target.result)
+      let jstr = { json_class: 'String', raw: [] }
+      for (let i = 0; i < bufView.length; i++) {
+        jstr.raw.push(bufView[i])
+      }
 
-    //   this.api.send_raw(this.selectedInterface, jstr).then(
-    //     () => {
-    //       this.displaySendRaw = false
-    //       this.status =
-    //         'Sent ' +
-    //         bufView.length +
-    //         ' bytes to interface ' +
-    //         this.selectedInterface
-    //     },
-    //     (error) => {
-    //       this.displaySendRaw = false
-    //       this.displayError('sending raw data', error, true)
-    //     }
-    //   )
-    // },
+      this.api.send_raw(this.selectedInterface, jstr).then(
+        () => {
+          this.displaySendRaw = false
+          this.status =
+            'Sent ' +
+            bufView.length +
+            ' bytes to interface ' +
+            this.selectedInterface
+        },
+        (error) => {
+          this.displaySendRaw = false
+          this.displayError('sending raw data', error, true)
+        },
+      )
+    },
 
-    // sendRawCmd() {
-    //   let self = this
-    //   let reader = new FileReader()
-    //   reader.onload = function (e) {
-    //     self.onLoad(e)
-    //   }
-    //   reader.onerror = function (e) {
-    //     self.displaySendRaw = false
-    //     let target = e.target
-    //     self.displayError('sending raw data', target.error, true)
-    //   }
-    //   // TBD - use the other event handlers to implement a progress bar for the
-    //   // file upload.  Handle abort as well?
-    //   //reader.onloadstart = function(e) {}
-    //   //reader.onprogress = function(e) {}
-    //   //reader.onloadend = function(e) {}
-    //   //reader.onabort = function(e) {}
-
-    //   reader.readAsArrayBuffer(this.rawCmdFile)
-    // },
+    sendRawCmd() {
+      if (!this.selectedInterface) {
+        this.displayError(
+          'sending raw data',
+          { name: 'Error', message: 'No interface selected' },
+          true,
+        )
+        return
+      }
+      if (!this.rawCmdFile) {
+        this.displayError(
+          'sending raw data',
+          { name: 'Error', message: 'No file selected' },
+          true,
+        )
+        return
+      }
+      let self = this
+      let reader = new FileReader()
+      reader.onload = function (e) {
+        self.onLoad(e)
+      }
+      reader.onerror = function (e) {
+        self.displaySendRaw = false
+        let target = e.target
+        self.displayError('sending raw data', target.error, true)
+      }
+      reader.readAsArrayBuffer(this.rawCmdFile)
+    },
 
     cancelRawCmd() {
       this.displaySendRaw = false

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
@@ -869,10 +869,10 @@ export default {
     setupRawCmd() {
       this.api.get_interface_names().then(
         (response) => {
-          let interfaces = []
-          for (let i = 0; i < response.length; i++) {
-            interfaces.push({ label: response[i], value: response[i] })
-          }
+          const interfaces = response.map((name) => ({
+            label: name,
+            value: name,
+          }))
           this.interfaces = interfaces
           this.selectedInterface = interfaces.length ? interfaces[0].value : ''
           this.rawCmdFile = null
@@ -889,30 +889,7 @@ export default {
       this.rawCmdFile = event.target.files[0]
     },
 
-    onLoad(event) {
-      let bufView = new Uint8Array(event.target.result)
-      let jstr = { json_class: 'String', raw: [] }
-      for (let i = 0; i < bufView.length; i++) {
-        jstr.raw.push(bufView[i])
-      }
-
-      this.api.send_raw(this.selectedInterface, jstr).then(
-        () => {
-          this.displaySendRaw = false
-          this.status =
-            'Sent ' +
-            bufView.length +
-            ' bytes to interface ' +
-            this.selectedInterface
-        },
-        (error) => {
-          this.displaySendRaw = false
-          this.displayError('sending raw data', error, true)
-        },
-      )
-    },
-
-    sendRawCmd() {
+    async sendRawCmd() {
       if (!this.selectedInterface) {
         this.displayError(
           'sending raw data',
@@ -929,17 +906,30 @@ export default {
         )
         return
       }
-      let self = this
-      let reader = new FileReader()
-      reader.onload = function (e) {
-        self.onLoad(e)
+      let bufView
+      try {
+        const buffer = await this.rawCmdFile.arrayBuffer()
+        bufView = new Uint8Array(buffer)
+      } catch (err) {
+        this.displaySendRaw = false
+        this.displayError('sending raw data', err, true)
+        return
       }
-      reader.onerror = function (e) {
-        self.displaySendRaw = false
-        let target = e.target
-        self.displayError('sending raw data', target.error, true)
-      }
-      reader.readAsArrayBuffer(this.rawCmdFile)
+      const jstr = { json_class: 'String', raw: Array.from(bufView) }
+      this.api.send_raw(this.selectedInterface, jstr).then(
+        () => {
+          this.displaySendRaw = false
+          this.status =
+            'Sent ' +
+            bufView.length +
+            ' bytes to interface ' +
+            this.selectedInterface
+        },
+        (error) => {
+          this.displaySendRaw = false
+          this.displayError('sending raw data', error, true)
+        },
+      )
     },
 
     cancelRawCmd() {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CommandEditor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CommandEditor.vue
@@ -271,26 +271,24 @@ export default {
       input.value = ''
       input.click()
     },
-    onBlockUploadFile(event) {
+    async onBlockUploadFile(event) {
       const file = event.target.files && event.target.files[0]
       if (!file || !this.selectedRow) return
       const targetRow = this.selectedRow
-      const reader = new FileReader()
-      reader.onload = (e) => {
-        const bytes = new Uint8Array(e.target.result)
+      try {
+        const buffer = await file.arrayBuffer()
+        const bytes = new Uint8Array(buffer)
         let hex = '0x'
-        for (let i = 0; i < bytes.length; i++) {
-          hex += bytes[i].toString(16).padStart(2, '0').toUpperCase()
+        for (const byte of bytes) {
+          hex += byte.toString(16).padStart(2, '0').toUpperCase()
         }
         // Setting val on the row updates the bound CommandParameterEditor.
         // The "0x..." prefix lets convertToValue parse it as a binary BLOCK.
         targetRow.val = hex
-      }
-      reader.onerror = () => {
+      } catch (err) {
         // eslint-disable-next-line no-console
-        console.error('Error reading uploaded file:', reader.error)
+        console.error('Error reading uploaded file:', err)
       }
-      reader.readAsArrayBuffer(file)
     },
     updateCmdParams() {
       this.ignoredParams = []

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CommandEditor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CommandEditor.vue
@@ -80,12 +80,21 @@
         <v-list-item
           v-for="(item, index) in contextMenuOptions"
           :key="index"
+          :data-test="item.dataTest"
           @click.stop="item.action"
         >
           <v-list-item-title>{{ item.title }}</v-list-item-title>
         </v-list-item>
       </v-list>
     </v-menu>
+
+    <input
+      ref="blockUploadInput"
+      type="file"
+      style="display: none"
+      data-test="block-upload-input"
+      @change="onBlockUploadFile($event)"
+    />
 
     <details-dialog
       v-model="viewDetails"
@@ -182,23 +191,38 @@ export default {
       contextMenuShown: false,
       viewDetails: false,
       parameterName: '',
+      selectedRow: null,
       hazardousParameters: {},
       x: 0,
       y: 0,
-      contextMenuOptions: [
-        {
-          title: 'Details',
-          action: () => {
-            this.contextMenuShown = false
-            this.viewDetails = true
-          },
-        },
-      ],
     }
   },
   computed: {
     hasHazardousParameter() {
       return Object.values(this.hazardousParameters).some((v) => v === true)
+    },
+    contextMenuOptions() {
+      const options = [
+        {
+          title: 'Details',
+          dataTest: 'cmd-param-details',
+          action: () => {
+            this.contextMenuShown = false
+            this.viewDetails = true
+          },
+        },
+      ]
+      if (this.selectedRow && this.selectedRow.type === 'BLOCK') {
+        options.push({
+          title: 'Upload Data',
+          dataTest: 'cmd-param-upload-data',
+          action: () => {
+            this.contextMenuShown = false
+            this.openBlockUploadPicker()
+          },
+        })
+      }
+      return options
     },
   },
   created() {
@@ -232,12 +256,41 @@ export default {
     showContextMenu(event, row) {
       event.preventDefault()
       this.parameterName = row.item.parameter_name
+      this.selectedRow = row.item
       this.contextMenuShown = false
       this.x = event.clientX
       this.y = event.clientY
       this.$nextTick(() => {
         this.contextMenuShown = true
       })
+    },
+    openBlockUploadPicker() {
+      const input = this.$refs.blockUploadInput
+      if (!input) return
+      // Reset so re-selecting the same file still fires @change
+      input.value = ''
+      input.click()
+    },
+    onBlockUploadFile(event) {
+      const file = event.target.files && event.target.files[0]
+      if (!file || !this.selectedRow) return
+      const targetRow = this.selectedRow
+      const reader = new FileReader()
+      reader.onload = (e) => {
+        const bytes = new Uint8Array(e.target.result)
+        let hex = '0x'
+        for (let i = 0; i < bytes.length; i++) {
+          hex += bytes[i].toString(16).padStart(2, '0').toUpperCase()
+        }
+        // Setting val on the row updates the bound CommandParameterEditor.
+        // The "0x..." prefix lets convertToValue parse it as a binary BLOCK.
+        targetRow.val = hex
+      }
+      reader.onerror = () => {
+        // eslint-disable-next-line no-console
+        console.error('Error reading uploaded file:', reader.error)
+      }
+      reader.readAsArrayBuffer(file)
     },
     updateCmdParams() {
       this.ignoredParams = []

--- a/playwright/tests/command-sender.p.spec.ts
+++ b/playwright/tests/command-sender.p.spec.ts
@@ -760,3 +760,62 @@ test('sends manually entered state values', async ({ page, utils }) => {
   // Close the dropdown by pressing Escape
   await page.keyboard.press('Escape')
 })
+
+test('uploads data into a BLOCK parameter via right-click', async ({
+  page,
+  utils,
+}) => {
+  await page.locator('[data-test="clear-history"]').click()
+  // INST MEMLOAD has a single BLOCK parameter named DATA
+  await utils.selectTargetPacketItem('INST', 'MEMLOAD')
+  await expect(page.locator('main')).toContainText('Parameters')
+
+  const dataRow = page.locator('tr:has(td:text-is("DATA"))')
+
+  // Set up the file chooser before right-clicking so the picker is captured
+  const fileChooserPromise = page.waitForEvent('filechooser')
+
+  // Right-click on the DATA row to open the context menu
+  await dataRow.click({ button: 'right' })
+  // The new Upload Data entry should be present for BLOCK parameters
+  const uploadItem = page.locator('[data-test=cmd-param-upload-data]')
+  await expect(uploadItem).toBeVisible()
+  await uploadItem.click()
+
+  // Provide a small payload via the file chooser
+  const fileChooser = await fileChooserPromise
+  await fileChooser.setFiles({
+    name: 'upload.bin',
+    mimeType: 'application/octet-stream',
+    buffer: Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+  })
+
+  // The BLOCK text field should now show the hex representation
+  await expect(
+    dataRow.locator('[data-test=cmd-param-value] input').first(),
+  ).toHaveValue('0xDEADBEEF')
+
+  // Non-BLOCK parameters should not see Upload Data
+  await utils.selectTargetPacketItem('INST', 'COLLECT')
+  await page.locator('tr:has(td:text-is("DURATION"))').click({ button: 'right' })
+  await expect(
+    page.locator('[data-test=cmd-param-upload-data]'),
+  ).not.toBeVisible()
+  await page.keyboard.press('Escape')
+})
+
+test('opens the Send Raw File dialog and lists interfaces', async ({
+  page,
+}) => {
+  // Open File > Send Raw File from the top bar
+  await page.locator('[data-test=command-sender-file]').click()
+  await page.locator('[data-test=command-sender-file-send-raw-file]').click()
+
+  // Dialog should be visible and show the interface picker
+  await expect(page.getByText('Send Raw')).toBeVisible()
+  await expect(page.locator('[data-test=send-raw-file]')).toBeVisible()
+
+  // Cancel and confirm status is updated
+  await page.getByRole('button', { name: 'Cancel' }).click()
+  await expect(page.locator('main')).toContainText('Raw command not sent')
+})


### PR DESCRIPTION
## Summary

Resolves #59 by adding two upload affordances to the Command Sender:

- **BLOCK parameter Upload Data right-click menu.** In the Command Editor parameter table, right-clicking a row whose parameter is BLOCK now adds an `Upload Data` entry alongside `Details`. Selecting it opens a hidden file input; the file is read with `FileReader.readAsArrayBuffer`, the bytes are encoded as `0x<HEX>`, and the value is written back into the row. The existing `convertToValue` BLOCK branch already turns that hex string into the `json_class: 'String'` payload the API expects.
- **File > Send Raw File menu option.** Wires up the previously stubbed `Send Raw` dialog in `CommandSender.vue`. The menu now fetches `get_interface_names`, presents the dialog with the existing interface picker + file input, reads the chosen file, and POSTs to `send_raw(interface_name, jstr)`. Status feedback flows through the existing status pipeline.

`Upload Data` is only offered for BLOCK parameters, so other rows behave exactly as before. No new dependencies. The reading code reuses the same `Uint8Array` / `json_class: 'String'` shape the rest of the tool uses for BLOCK data and matches the original draft that the file already shipped commented-out.

## Test plan

A new parallel Playwright test (`playwright/tests/command-sender.p.spec.ts`) covers both features against the existing INST demo target:

- [ ] `uploads data into a BLOCK parameter via right-click` — selects INST MEMLOAD, right-clicks the DATA BLOCK row, supplies a 4-byte payload via `filechooser`, and asserts the field becomes `0xDEADBEEF`. Then checks that INST COLLECT's non-BLOCK DURATION row does not show the new menu entry.
- [ ] `opens the Send Raw File dialog and lists interfaces` — opens File > Send Raw File, asserts the dialog appears with the file input, cancels, and checks `Raw command not sent` status.
- [ ] `pnpm lint --max-warnings 0` passes for both `openc3-cosmos-tool-cmdsender` and `openc3-vue-common`.

Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)