### PR TITLE
Fix trigger_model and activity_controller

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/controllers/activity_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/activity_controller.rb
@@ -72,7 +72,7 @@ class ActivityController < ApplicationController
   # ```
   def create
     return unless authorization('script_run')
-    hash = params.permit(:start, :stop, :kind, :recurring, data: {}).to_h
+    hash = params.permit(:start, :stop, :kind, data: {}, recurring: {}).to_h
     begin
       hash['data'] ||= {}
       hash['data']['username'] = username()

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/activity_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/activity_controller_spec.rb
@@ -162,6 +162,41 @@ RSpec.describe ActivityController, type: :controller do
       expect(ret["name"]).to eql("test")
       expect(response).to have_http_status(:created)
     end
+
+    it "passes recurring hash through strong params and creates multiple activities" do
+      dt = DateTime.now.new_offset(0)
+      start_time = dt + (1.0 / 24.0)
+      stop_time = start_time + (30.0 / 1440.0) # 30 minutes after start
+      end_time = start_time + (5.0 / 24.0) # 5 hours after start
+      hash = {
+        "start" => start_time.to_s,
+        "stop" => stop_time.to_s,
+        "kind" => "RESERVE",
+        "data" => {"reserve" => ""},
+        "recurring" => {
+          "frequency" => "60",
+          "span" => "minutes",
+          "end" => end_time.to_s,
+        }
+      }
+      post :create, params: hash.merge({"scope" => timeline_scope, "name" => timeline_name})
+      expect(response).to have_http_status(:created)
+      ret = JSON.parse(response.body, allow_nan: true, create_additions: true)
+      expect(ret["recurring"]).not_to be_nil
+      expect(ret["recurring"]["frequency"]).to eql("60")
+      expect(ret["recurring"]["span"]).to eql("minutes")
+      expect(ret["recurring"]["end"]).not_to be_nil
+
+      # Verify multiple activities were created across the recurring window
+      get :index, params: {
+        "scope" => timeline_scope,
+        "name" => timeline_name,
+        "start" => start_time.to_s,
+        "stop" => (end_time + (1.0 / 24.0)).to_s,
+      }
+      activities = JSON.parse(response.body, allow_nan: true, create_additions: true)
+      expect(activities.length).to be > 1
+    end
   end
 
   describe "POST event" do

--- a/openc3/lib/openc3/models/trigger_model.rb
+++ b/openc3/lib/openc3/models/trigger_model.rb
@@ -107,7 +107,7 @@ module OpenC3
       group:,
       left:,
       operator:,
-      right:,
+      right: nil,
       state: false,
       enabled: true,
       dependents: nil,

--- a/openc3/spec/models/trigger_model_spec.rb
+++ b/openc3/spec/models/trigger_model_spec.rb
@@ -292,6 +292,35 @@ module OpenC3
         ).create()
       end
 
+      it "allows omitting right entirely when operator is CHANGE oriented" do
+        # Simulates strong params filtering nil right from controller payload
+        json = {
+          'group' => TMO_GROUP,
+          'left' => {'type' => 'item', 'target' => 'TGT', 'packet' => 'PKT', 'item' => 'ITEM', 'valueType' => 'CONVERTED'},
+          'operator' => 'DOES NOT CHANGE',
+          'label' => nil,
+        }
+        model = TriggerModel.from_json(json, name: 'TRIG3', scope: $openc3_scope)
+        expect(model.right).to be_nil
+        model.create()
+
+        json['operator'] = 'CHANGES'
+        model = TriggerModel.from_json(json, name: 'TRIG4', scope: $openc3_scope)
+        expect(model.right).to be_nil
+        model.create()
+      end
+
+      it "raises when right is omitted and operator requires it" do
+        json = {
+          'group' => TMO_GROUP,
+          'left' => {'type' => 'item', 'target' => 'TGT', 'packet' => 'PKT', 'item' => 'ITEM', 'valueType' => 'CONVERTED'},
+          'operator' => '>',
+        }
+        expect {
+          TriggerModel.from_json(json, name: 'TRIG5', scope: $openc3_scope)
+        }.to raise_error(TriggerInputError, /invalid operand/)
+      end
+
       it "raises when given a bad operand" do
         expect {
           generate_trigger(


### PR DESCRIPTION
Strong params filters `right: nil` (only permits hashes), so if the `right: key` was missing in the hash passed to TriggerModel.from_json you get `missing keyword: :right`.

Same for activity_controller. `params.permit(:start, :stop, :kind, :recurring, data: {})` and recurring declared as scalar but frontend sends hash {frequency, span, end}. The strong params filters it so only a single activity created.