### PR TITLE
fix(script-runner): chain file upload promise to fix open_file_dialog

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -2466,12 +2466,10 @@ export default {
             ).then((response) => {
               // This pushes the file into storage by using the fields in the presignedRequest
               // See storage_controller.rb get_upload_presigned_request()
-              promises.push(
-                axios({
-                  ...response.data,
-                  data: file,
-                }),
-              )
+              return axios({
+                ...response.data,
+                data: file,
+              })
             }),
           )
         })


### PR DESCRIPTION
Return the axios upload promise from the .then() callback instead of pushing it into the promises array. This ensures Promise.all waits for the actual file upload to complete before notifying the script backend, fixing "File not found" errors when the file doesn't already exist in storage.

Tested with 

```python
with open_file_dialog("Open a single file", "Choose something interesting", filter=".pdf") as file:
  print(file)
  print(file.read(1000))
```

Fixes #3356 