### PR TITLE
Bump dagre to 3.0.0

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrouxds/astro-web-components": "7.27.0",
-    "@dagrejs/dagre": "2.0.4",
+    "@dagrejs/dagre": "3.0.0",
     "@openc3/js-common": "workspace:*",
     "@openc3/vue-common": "workspace:*",
     "@vue-flow/background": "1.3.2",

--- a/openc3-cosmos-init/plugins/pnpm-lock.yaml
+++ b/openc3-cosmos-init/plugins/pnpm-lock.yaml
@@ -187,8 +187,8 @@ importers:
         specifier: 7.27.0
         version: 7.27.0
       '@dagrejs/dagre':
-        specifier: 2.0.4
-        version: 2.0.4
+        specifier: 3.0.0
+        version: 3.0.0
       '@openc3/js-common':
         specifier: workspace:*
         version: link:../openc3-js-common
@@ -965,11 +965,11 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
-  '@dagrejs/dagre@2.0.4':
-    resolution: {integrity: sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==}
+  '@dagrejs/dagre@3.0.0':
+    resolution: {integrity: sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==}
 
-  '@dagrejs/graphlib@3.0.4':
-    resolution: {integrity: sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg==}
+  '@dagrejs/graphlib@4.0.1':
+    resolution: {integrity: sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -2567,11 +2567,11 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
-  '@dagrejs/dagre@2.0.4':
+  '@dagrejs/dagre@3.0.0':
     dependencies:
-      '@dagrejs/graphlib': 3.0.4
+      '@dagrejs/graphlib': 4.0.1
 
-  '@dagrejs/graphlib@3.0.4': {}
+  '@dagrejs/graphlib@4.0.1': {}
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true


### PR DESCRIPTION
To test load the Data Flows and verify it still works. I thought we would require additional changes so I was holding off on this but no changes were required. According to the [changelog](https://github.com/dagrejs/dagre/blob/master/changelog.md) they did a full typescript rewrite and standardized ESM and CommonJS exports.