### PR TITLE
fix CanvaslabelWidget.vue parameter mapping to match documentation an…

### DIFF
--- a/docs.openc3.com/docs/configuration/telemetry-screens.md
+++ b/docs.openc3.com/docs/configuration/telemetry-screens.md
@@ -1805,6 +1805,8 @@ END
 | Image filename | Name of a image file. The file must be in the plugin's targets/TARGET/public directory. | True |
 | X Position | X position of the upper-left corner of the image on the canvas | True |
 | Y Position | Y position of the upper-left corner of the image on the canvas | True |
+| Width | Width of the image in pixels (default is 100%) | False |
+| Height | Height of the image in pixels (default is 100%) | False |
 
 Example Usage:
 ```cosmos

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/CanvaslabelWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/CanvaslabelWidget.vue
@@ -16,7 +16,7 @@
 -->
 
 <template>
-  <text :x="parameters[0]" :y="parameters[1]" :fill="fillColor">
+  <text :x="parameters[0]" :y="parameters[1]" :font-size="fontSize" :fill="fillColor">
     {{ parameters[2] }}
   </text>
 </template>
@@ -26,9 +26,15 @@ import Widget from './Widget'
 export default {
   mixins: [Widget],
   computed: {
-    fillColor() {
+    fontSize() {
       if (this.parameters[3]) {
-        return this.parameters[3]
+        return this.parameters[3] + 'px'
+      }
+      return '12px'
+    },
+    fillColor() {
+      if (this.parameters[4]) {
+        return this.parameters[4]
       }
       return 'black'
     },


### PR DESCRIPTION
fix `CanvaslabelWidget.vue` parameter mapping to match documentation and correct mapping of font size and font color. 

While I was fixing the above, I noticed that the `CANVASIMAGE` docs were missing documentation for the width and height parameters that are part of the source implementation

Fixes https://github.com/OpenC3/cosmos/issues/3400