### PR TITLE
docs(tlm_api): document get_packets cross-stream ordering

### DIFF
--- a/docs.openc3.com/docs/guides/script-writing.md
+++ b/docs.openc3.com/docs/guides/script-writing.md
@@ -643,6 +643,8 @@ value = tlm("INST LATEST TEMP")
 
 When writing COSMOS scripts, checking the most recent value of a telemetry point normally gets the job done. The tlm(), tlm_raw(), etc methods all retrieve the most recent value of a telemetry point. Sometimes you need to perform analysis on every single sample of a telemetry point. This can be done using the COSMOS packet subscription system. The packet subscription system lets you choose one or more packets and receive them all from a queue. You can then pick out the specific telemetry points you care about from each packet. See the [Packet Data Subscriptions](scripting-api.md#packet-data-subscriptions) section of the Scripting API guide for the complete API documentation including the packet hash/dictionary structure.
 
+Note: when subscribing to multiple packets, packets returned from `get_packets` are ordered within each packet stream but are NOT interleaved by time across streams. Sort the returned array by the `time` field if you need chronological order across packets from different streams.
+
 <Tabs groupId="script-language">
 <TabItem value="python" label="Python">
 

--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -3835,6 +3835,20 @@ id, packets = get_packets(id, block: nil, count: 1000)
 | block     | Number of seconds to block while waiting for packets from ANY stream, default nil / None (do not block) |
 | count     | Maximum number of packets to return from EACH packet stream                                             |
 
+:::note Packet Ordering
+Packets returned by `get_packets` are ordered within each subscribed packet stream (target/packet pair) but are NOT interleaved by time across streams. Packets from one stream are appended to the returned array, then packets from the next stream, and so on. If you require strict chronological order across packets from different streams, sort the returned array by the `time` (or `received_time`) field. Note that sorting only orders the current batch — packets across separate `get_packets` calls may still arrive out of order relative to each other, so subscribers needing global ordering must buffer and merge across calls.
+
+```python
+id, packets = get_packets(id)
+packets.sort(key=lambda p: int(p['time']))
+```
+
+```ruby
+id, packets = get_packets(id)
+packets.sort_by! { |p| p['time'].to_i }
+```
+:::
+
 Returns a two element array containing the updated id and an array of packet hashes/dictionaries. Each packet hash/dictionary contains the following keys:
 
 **Metadata keys:**

--- a/openc3/lib/openc3/api/tlm_api.rb
+++ b/openc3/lib/openc3/api/tlm_api.rb
@@ -457,6 +457,12 @@ module OpenC3
     alias subscribe_packet subscribe_packets
 
     # Get packets based on ID returned from subscribe_packet.
+    # Packets are ordered within each subscribed packet stream (target/packet pair)
+    # but are NOT interleaved by time across streams. If chronological order across
+    # streams is required, sort the returned array by the 'time' field. Sorting only
+    # orders the current batch - packets across separate get_packets calls may still
+    # arrive out of order, so subscribers needing global ordering must buffer and merge
+    # across calls.
     # @param id [String] ID returned from subscribe_packets or last call to get_packets
     # @param block [Integer] Unused - Blocking must be implemented at the client
     # @param count [Integer] Maximum number of packets to return from EACH packet stream

--- a/openc3/python/openc3/api/tlm_api.py
+++ b/openc3/python/openc3/api/tlm_api.py
@@ -530,6 +530,13 @@ def subscribe_packets(packets, scope=OPENC3_SCOPE):
 def get_packets(id, count=1000, scope=OPENC3_SCOPE):
     """Get packets based on ID returned from subscribe_packet.
 
+    Packets are ordered within each subscribed packet stream (target/packet pair)
+    but are NOT interleaved by time across streams. If chronological order across
+    streams is required, sort the returned list by the 'time' field. Sorting only
+    orders the current batch - packets across separate get_packets calls may still
+    arrive out of order, so subscribers needing global ordering must buffer and merge
+    across calls.
+
     Args:
         id (str) ID returned from subscribe_packets or last call to get_packets
         count (int) Maximum number of packets to return from EACH packet stream


### PR DESCRIPTION
## Summary
- Document that `get_packets` orders packets within each stream but does not interleave by time across streams (fixes #3337).
- Add admonition with Python/Ruby sort snippets under the `get_packets` API reference; note sorting only fixes the current batch (cross-call ordering still requires user buffering).
- Add short callout to the script-writing guide and update Ruby/Python API docstrings.

## Test plan
- [ ] Render docs site locally and confirm admonition renders in `scripting-api.md` under `get_packets`.
- [ ] Confirm script-writing.md note appears in "Checking Every Single Sample" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)