### PR TITLE
Fix Tlm Viewer -> Tlm Grapher for indexed array items

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/VWidget.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/VWidget.js
@@ -163,7 +163,8 @@ export default {
         '/' +
         encodeURIComponent(this.parameters[2])
       if (this.arrayIndex !== null) {
-        url += `[${this.arrayIndex}]`
+        // square brackets must be encoded, unencoded they break the keycloak redirect_uri
+        url += encodeURIComponent(`[${this.arrayIndex}]`)
       }
       return url + '/'
     },

--- a/playwright/tests/tlm-viewer.p.spec.ts
+++ b/playwright/tests/tlm-viewer.p.spec.ts
@@ -475,7 +475,7 @@ test('links array item to TlmGrapher', async ({ page, utils }) => {
     await page.getByText('Graph', { exact: true }).click()
     const graphPage = await graphPagePromise
     await expect(graphPage).toHaveURL(
-      /\/tools\/tlmgrapher\/INST\/HEALTH_STATUS\/ARY\[0\]/,
+      new RegExp(`/tools/tlmgrapher/INST/HEALTH_STATUS/ARY${encodeURIComponent('[0]')}`),
     )
     await graphPage.close()
   })


### PR DESCRIPTION
encode array index portion of url for tlm grapher

# Bug Repro
With demo plugin running, **IN ENTERPRISE**
1. Go to Tlm Viewer
2. Show "INST ARRAY" screen
3. Right click on the value box of `ARY[0]` or `ARY[1]`
4. Click "Graph" from context menu

EXPECT: Tlm Grapher opens in new tab with that array item graphed
ACTUAL: New tab opens with auth error about "Invalid parameter: redirect_uri"