### PR TITLE
fix settings config empty checkboxes

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/Config.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/Config.js
@@ -43,7 +43,7 @@ export default {
       }
     },
     saveDefaultConfig: function (config) {
-      if (this.dontSaveDefaultConfig === true) {
+      if (this.dontSaveDefaultConfig) {
         return
       }
       localStorage.setItem(this.storageKey, JSON.stringify(config))

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/Config.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/Config.js
@@ -13,6 +13,7 @@
 
 import { OpenC3Api } from '@openc3/js-common/services'
 
+export const CONFIG_POSTFIX = '__default'
 export default {
   data: {
     // Applications can set to avoid persisting default config
@@ -27,10 +28,15 @@ export default {
       )
     }
   },
+  computed: {
+    storageKey() {
+      return `${this.configKey}${CONFIG_POSTFIX}`
+    },
+  },
   methods: {
     loadDefaultConfig: function () {
-      if (localStorage[`${this.configKey}__default`]) {
-        return JSON.parse(localStorage[`${this.configKey}__default`])
+      if (localStorage[this.storageKey]) {
+        return JSON.parse(localStorage[this.storageKey])
       } else {
         return {}
       }
@@ -39,7 +45,7 @@ export default {
       if (this.dontSaveDefaultConfig === true) {
         return
       }
-      localStorage[`${this.configKey}__default`] = JSON.stringify(config)
+      localStorage[this.storageKey] = JSON.stringify(config)
     },
     openConfigBase: function (name, routed = false, callback = null) {
       new OpenC3Api()
@@ -95,7 +101,7 @@ export default {
         })
     },
     resetConfigBase: function () {
-      localStorage.removeItem(`${this.configKey}__default`)
+      localStorage.removeItem(this.storageKey)
 
       const query = { ...this.$route.query }
       delete query.config

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/Config.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/Config.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2023 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -15,10 +15,17 @@ import { OpenC3Api } from '@openc3/js-common/services'
 
 export default {
   data: {
-    configKey: '',
     // Applications can set to avoid persisting default config
     // Useful when loading and setting existing config
     dontSaveDefaultConfig: false,
+  },
+  created: function () {
+    if (!this.configKey) {
+      alert('Components using the Config mixin must provide a configKey')
+      throw new Error(
+        'Components using the Config mixin must provide a configKey',
+      )
+    }
   },
   methods: {
     loadDefaultConfig: function () {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/Config.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/Config.js
@@ -35,8 +35,9 @@ export default {
   },
   methods: {
     loadDefaultConfig: function () {
-      if (localStorage[this.storageKey]) {
-        return JSON.parse(localStorage[this.storageKey])
+      const config = localStorage.getItem(this.storageKey)
+      if (config) {
+        return JSON.parse(config)
       } else {
         return {}
       }
@@ -45,7 +46,7 @@ export default {
       if (this.dontSaveDefaultConfig === true) {
         return
       }
-      localStorage[this.storageKey] = JSON.stringify(config)
+      localStorage.setItem(this.storageKey, JSON.stringify(config))
     },
     openConfigBase: function (name, routed = false, callback = null) {
       new OpenC3Api()

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/index.js
@@ -11,8 +11,8 @@
 # if purchased from OpenC3, Inc.
 */
 
-import Config from './Config'
+import Config, { CONFIG_POSTFIX } from './Config'
 import OpenConfigDialog from './OpenConfigDialog.vue'
 import SaveConfigDialog from './SaveConfigDialog.vue'
 
-export { Config, OpenConfigDialog, SaveConfigDialog }
+export { Config, CONFIG_POSTFIX, OpenConfigDialog, SaveConfigDialog }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/index.js
@@ -11,8 +11,6 @@
 # if purchased from OpenC3, Inc.
 */
 
-import Config, { CONFIG_POSTFIX } from './Config'
-import OpenConfigDialog from './OpenConfigDialog.vue'
-import SaveConfigDialog from './SaveConfigDialog.vue'
-
-export { Config, CONFIG_POSTFIX, OpenConfigDialog, SaveConfigDialog }
+export { default as Config, CONFIG_POSTFIX } from './Config'
+export { default as OpenConfigDialog } from './OpenConfigDialog.vue'
+export { default as SaveConfigDialog } from './SaveConfigDialog.vue'

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/index.js
@@ -13,12 +13,8 @@
 
 import { AceEditorModes, AceEditorUtils } from './ace'
 import { ScreenCompleter } from './autocomplete'
-import {
-  Config,
-  CONFIG_POSTFIX,
-  OpenConfigDialog,
-  SaveConfigDialog,
-} from './config'
+import { Config, OpenConfigDialog, SaveConfigDialog } from './config'
+export { CONFIG_POSTFIX } from './config'
 import CommandEditor from './CommandEditor.vue'
 import CommandParameterEditor from './CommandParameterEditor.vue'
 import CriticalCmdDialog from './CriticalCmdDialog.vue'
@@ -50,7 +46,6 @@ export {
   AceEditorUtils,
   ScreenCompleter,
   Config,
-  CONFIG_POSTFIX,
   OpenConfigDialog,
   SaveConfigDialog,
   CommandEditor,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/index.js
@@ -13,7 +13,12 @@
 
 import { AceEditorModes, AceEditorUtils } from './ace'
 import { ScreenCompleter } from './autocomplete'
-import { Config, OpenConfigDialog, SaveConfigDialog } from './config'
+import {
+  Config,
+  CONFIG_POSTFIX,
+  OpenConfigDialog,
+  SaveConfigDialog,
+} from './config'
 import CommandEditor from './CommandEditor.vue'
 import CommandParameterEditor from './CommandParameterEditor.vue'
 import CriticalCmdDialog from './CriticalCmdDialog.vue'
@@ -45,6 +50,7 @@ export {
   AceEditorUtils,
   ScreenCompleter,
   Config,
+  CONFIG_POSTFIX,
   OpenConfigDialog,
   SaveConfigDialog,
   CommandEditor,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/DefaultConfigSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/DefaultConfigSettings.vue
@@ -94,7 +94,7 @@ export default {
     },
     deleteLocalStorageKeys: function (keys) {
       for (const key of keys) {
-        delete localStorage[key]
+        localStorage.removeItem(key)
       }
     },
   },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/DefaultConfigSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/DefaultConfigSettings.vue
@@ -75,6 +75,10 @@ export default {
   },
   methods: {
     loadLastConfigs: function () {
+      // if there is a localStorage value that is missing a configKey, delete it
+      if (localStorage.getItem(CONFIG_POSTFIX)) {
+        localStorage.removeItem(CONFIG_POSTFIX)
+      }
       this.lastConfigs = Object.keys(localStorage)
         .filter((key) => {
           return key.endsWith(CONFIG_POSTFIX)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/DefaultConfigSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/DefaultConfigSettings.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2024 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -51,6 +51,8 @@
 </template>
 
 <script>
+import { CONFIG_POSTFIX } from '@/components'
+
 export default {
   data() {
     return {
@@ -75,7 +77,7 @@ export default {
     loadLastConfigs: function () {
       this.lastConfigs = Object.keys(localStorage)
         .filter((key) => {
-          return key.endsWith('__default')
+          return key.endsWith(CONFIG_POSTFIX)
         })
         .map((key) => {
           const name = key.split('__')[0].replaceAll('_', ' ')


### PR DESCRIPTION
Closes #3435

- deletes localStorage key of just `__default`
- shares `'__default'` as a variable to prevent any misspelling
- Config mixin requires `configKey` to be provided by the component, enforced by presenting an alert in the browser and then throwing an error if it is missing