### PR TITLE
script_run improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,9 +165,14 @@ pnpm lint                     # ESLint, run from the openc3-cosmos-init/plugins/
 
 ### API Tests (Rails)
 
+The Rails APIs depend on the local `openc3` gem, which must be built first (see
+Ruby Tests above). Set `OPENC3_DEVEL` to the path of the local `openc3` gem so
+Bundler resolves it from source instead of trying to fetch it from RubyGems.
+
 ```bash
-cd openc3-cosmos-cmd-tlm-api && bundle exec rspec
-cd openc3-cosmos-script-runner-api && bundle exec rspec
+export OPENC3_DEVEL=../openc3
+cd openc3-cosmos-cmd-tlm-api && bundle install && bundle exec rspec
+cd openc3-cosmos-script-runner-api && bundle install && bundle exec rspec
 ```
 
 ### Playwright E2E Tests

--- a/docs.openc3.com/docs/getting-started/cli.md
+++ b/docs.openc3.com/docs/getting-started/cli.md
@@ -158,7 +158,7 @@ script complete
 %
 ```
 
-You can also run Test Runner suites by passing the `--suite SUITE`, `--group GROUP`, and `--script SCRIPT` options as shown below. Pass the `--method` option to run `--method setup` or `--method teardown`. The default is `--method start`. In addition you can pass an `--options` argument to control the flags set in the Test Runner GUI and a `--format` option to output results as `text` (default) or `ctrf` for CI/CD integration. See the CLI help for more information.
+You can also run Test Runner suites by passing the `--suite SUITE`, `--group GROUP`, and `--script SCRIPT` options as shown below. Pass the `--method` option to run `--method setup` or `--method teardown`. The default is `--method start`. In addition you can pass an `--options` argument to control the flags set in the Test Runner GUI (the default is `continueAfterError`) and a `--format` option to output results as `text` (default) or `ctrf` for CI/CD integration. See the CLI help for more information.
 
 **Text Format (default):**
 

--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -8069,10 +8069,19 @@ script_run("<Script Name>", disconnect: false, environment: nil, suite_runner: n
 
 | Parameter    | Description                                                                                                         |
 | ------------ | ------------------------------------------------------------------------------------------------------------------- |
-| Script Name  | Full path name of the script starting with the target                                                               |
-| disconnect   | Whether to run the script in Disconnect mode                                                                        |
+| Script Name  | Full path name of the script starting with the target. If this is the path to a test suite file, the `suite_runner` parameter must also be provided. |
+| disconnect   | Boolean indicating whether to run the script in Disconnect |
 | environment  | Hash / dict of key / value items to set as script environment variables. Note: Do not use `PATH` as it is reserved. |
-| suite_runner | Hash / dict of suite runner options                                                                                 |
+| suite_runner | Hash / dict of suite runner configuration values. Valid keys are described [below](#script_run-suite_runner-parameter). |
+
+#### script_run suite_runner parameter
+| Key | Value |
+|-----|-------|
+| method | Required; valid values are "start", "setup", and "teardown". If `script` is provided, this value is ignored and `start` is always used. |
+| suite | Required; the name of the suite to run. Must be a valid suite within the given file. |
+| group | The name of the group to run. Must be a valid group within the given suite. If `script` is provided, this is required. |
+| script | The name of the specific script to run. Must be a valid method name within the given group. |
+| options | Array of strings of suite runner options to enable. Valid options are: "manual", "pauseOnError", "continueAfterError", "abortAfterError", "loop", and "breakLoopOnError". |
 
 <Tabs groupId="script-language">
 <TabItem value="python" label="Python Example">
@@ -8080,7 +8089,7 @@ script_run("<Script Name>", disconnect: false, environment: nil, suite_runner: n
 ```python
 id = script_run("INST2/procedures/checks.py", environment={ 'USER': 'JASON'})
 print(id)
-id = script_run("INST2/procedures/my_script_suite.py", suite_runner={ 'suite': 'MySuite', 'group': 'ExampleGroup', 'script': 'script_2' })
+id = script_run("INST2/procedures/my_script_suite.py", suite_runner={ 'suite': 'MySuite', 'group': 'ExampleGroup', 'script': 'script_2', 'method': 'start' })
 print(id)
 ```
 

--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -8077,11 +8077,11 @@ script_run("<Script Name>", disconnect: false, environment: nil, suite_runner: n
 #### script_run suite_runner parameter
 | Key | Value |
 |-----|-------|
-| method | Required; valid values are "start", "setup", and "teardown". If `script` is provided, this value is ignored and `start` is always used. |
+| method | Valid values are "start", "setup", and "teardown". Defaults to "start" if not provided. If `script` is provided, this value is ignored and `start` is always used. |
 | suite | Required; the name of the suite to run. Must be a valid suite within the given file. |
 | group | The name of the group to run. Must be a valid group within the given suite. If `script` is provided, this is required. |
 | script | The name of the specific script to run. Must be a valid method name within the given group. |
-| options | Array of strings of suite runner options to enable. Valid options are: "manual", "pauseOnError", "continueAfterError", "abortAfterError", "loop", and "breakLoopOnError". |
+| options | Array of strings of suite runner options to enable. Valid options are: "manual", "pauseOnError", "continueAfterError", "abortAfterError", "loop", and "breakLoopOnError". Defaults to ["continueAfterError"] if not provided. |
 
 <Tabs groupId="script-language">
 <TabItem value="python" label="Python Example">

--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -8045,7 +8045,7 @@ script_delete("INST/procedures/checks.rb")
 
 <span class="badge badge--secondary since-heading">Since 5.0.0</span>
 
-Runs a script in Script Runner. The script will run in the background and can be opened in Script Runner by selecting Script->Execution Status and then connecting to it.
+Kicks off running a script in Script Runner. The script will run in the background, while the caller continues to run, and can be opened in Script Runner by selecting "Execution Status" from the "Script" menu at the top, and then connecting to it from the "Running Scripts" tab.
 
 Note: In Enterprise, initialize_offline_access must have been called at least once for the user who calls this method.
 

--- a/openc3-cosmos-script-runner-api/app/controllers/scripts_controller.rb
+++ b/openc3-cosmos-script-runner-api/app/controllers/scripts_controller.rb
@@ -121,7 +121,7 @@ class ScriptsController < ApplicationController
       OpenC3::Logger.info("Script started: #{name}", scope: scope, user: username())
       render plain: running_script_id.to_s
     else
-      head :not_found
+      render plain: "Script not found: #{name}", status: :not_found
     end
   end
 

--- a/openc3-cosmos-script-runner-api/spec/controllers/scripts_controller_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/controllers/scripts_controller_spec.rb
@@ -143,10 +143,11 @@ RSpec.describe ScriptsController, type: :controller do
       expect(response).to have_http_status(:ok)
     end
 
-    it "returns an error response" do
-      expect(Script).to receive(:run).with("DEFAULT", "INST/procedures/test.rb", nil, false, nil, "Anonymous", "anonymous", 1, nil)
+    it "returns a not found response with the script name when the script does not exist" do
+      expect(Script).to receive(:run).with("DEFAULT", "INST/procedures/test.rb", nil, false, nil, "Anonymous", "anonymous", 1, nil).and_return(nil)
       post :run, params: {scope: "DEFAULT", name: "INST/procedures/test.rb"}
       expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("INST/procedures/test.rb")
     end
   end
 

--- a/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
@@ -140,6 +140,43 @@ RSpec.describe RunningScript, type: :model do
     end
   end
 
+  describe "#run with suite_runner" do
+    before do
+      # Avoid hitting the bucket when RunningScript#initialize fetches the body
+      allow(::Script).to receive(:body).and_return("puts 'test'")
+    end
+
+    it "uses the default method and options when the suite_runner omits them" do
+      script_status.suite_runner = { "suite" => "MySuite", "group" => "MyGroup" }
+      running_script = RunningScript.new(script_status)
+      # run_text instruments and executes the generated call; mock it so we
+      # can assert the dispatch string without actually running anything.
+      expect(running_script).to receive(:run_text).with(
+        "OpenC3::SuiteRunner.start(MySuite, MyGroup)", initial_filename: "SCRIPTRUNNER"
+      )
+
+      running_script.run
+
+      # DEFAULT_OPTIONS (['continueAfterError']) were applied
+      expect(OpenC3::SuiteRunner.settings["Continue After Error"]).to be true
+    end
+
+    it "uses the provided method and options when given" do
+      script_status.suite_runner = {
+        "suite" => "MySuite", "group" => "MyGroup", "method" => "teardown", "options" => ["manual"]
+      }
+      running_script = RunningScript.new(script_status)
+      expect(running_script).to receive(:run_text).with(
+        "OpenC3::SuiteRunner.teardown(MySuite, MyGroup)", initial_filename: "SCRIPTRUNNER"
+      )
+
+      running_script.run
+
+      expect(OpenC3::SuiteRunner.settings["Manual"]).to be true
+      expect(OpenC3::SuiteRunner.settings["Continue After Error"]).to be false
+    end
+  end
+
   describe "self.instrument_script" do
     it "adds instrumentation code to Ruby scripts" do
       simple_script = "puts 'Hello'"

--- a/openc3-cosmos-script-runner-api/spec/models/script_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/models/script_spec.rb
@@ -199,11 +199,19 @@ RSpec.describe Script, type: :model do
 
   describe "self.run" do
     it "spawns a running script" do
+      allow(Script).to receive(:body).with("DEFAULT", "script.rb").and_return("puts 'Hello'")
       expect(RunningScript).to receive(:spawn).with(
         "DEFAULT", "script.rb", nil, false, nil, "User Name", "username", nil, nil
-      )
+      ).and_return(12345)
 
-      Script.run("DEFAULT", "script.rb", nil, false, nil, "User Name", "username")
+      expect(Script.run("DEFAULT", "script.rb", nil, false, nil, "User Name", "username")).to be 12345
+    end
+
+    it "returns nil and does not spawn if the script does not exist" do
+      allow(Script).to receive(:body).with("DEFAULT", "missing.rb").and_return(nil)
+      expect(RunningScript).not_to receive(:spawn)
+
+      expect(Script.run("DEFAULT", "missing.rb", nil, false, nil, "User Name", "username")).to be_nil
     end
   end
 

--- a/openc3/bin/openc3cli
+++ b/openc3/bin/openc3cli
@@ -671,30 +671,18 @@ def cli_script_list(args, options)
 end
 
 def parse_suite_runner_options(options)
-  suite_runner = nil
   # suite must be given to enable Suite Runner execution
-  if options[:suite]
-    suite_runner = {}
-    suite_runner['suite'] = options[:suite]
-    if options[:group]
-      suite_runner['group'] = options[:group]
-      # script requires group to be set
-      if options[:script]
-        suite_runner['script'] = options[:script]
-      end
-    end
-    if options[:method]
-      suite_runner['method'] = options[:method]
-    else
-      suite_runner['method'] = 'start'
-    end
-    if options[:options]
-      suite_runner['options'] = options[:options].split(',')
-    else
-      suite_runner['options'] = ["continueAfterError"]
-    end
-  end
-  return suite_runner
+  return nil unless options[:suite]
+  require 'openc3/script/suite_runner'
+  # Build the canonical hash via the shared helper so the CLI applies the same
+  # shape, defaults, and validation (e.g. script requires group) as execution.
+  return OpenC3::SuiteRunner.build_options(
+    suite: options[:suite],
+    group: options[:group],
+    script: options[:script],
+    method: options[:method],
+    options: options[:options]&.split(','),
+  )
 end
 
 def cli_script_run(args, options)

--- a/openc3/lib/openc3/script/suite_runner.rb
+++ b/openc3/lib/openc3/script/suite_runner.rb
@@ -47,11 +47,11 @@ module OpenC3
       # Surface invalid suite / group / option combinations rather than
       # silently running nothing or failing with an opaque nil error. An
       # invalid script method raises later in Group#run_method.
-      raise "Script #{script} requires a Group" if script and not group_class
+      raise ArgumentError, "Script #{script} requires a Group" if script and not group_class
       suite = @@suites.find { |s| s.class == suite_class }
-      raise "Suite #{suite_class} not found" unless suite
+      raise ArgumentError, "Suite #{suite_class} not found" unless suite
       if group_class and not suite.scripts.key?(group_class)
-        raise "Group #{group_class} not found in Suite #{suite_class}"
+        raise ArgumentError, "Group #{group_class} not found in Suite #{suite_class}"
       end
       @@suite_results.start(result_string, suite_class, group_class, script, @@settings)
       loop do

--- a/openc3/lib/openc3/script/suite_runner.rb
+++ b/openc3/lib/openc3/script/suite_runner.rb
@@ -26,6 +26,11 @@ module OpenC3
   end
 
   class SuiteRunner
+    # Default suite_runner options shared by all callers (e.g. openc3cli) so
+    # the values stay consistent in one place.
+    DEFAULT_METHOD = 'start'
+    DEFAULT_OPTIONS = ['continueAfterError'].freeze
+
     @@suites = []
     @@settings = {}
     @@suite_results = nil
@@ -42,12 +47,37 @@ module OpenC3
       @@suite_results
     end
 
+    # Validate the suite_runner option combinations that don't require the
+    # built suites. Shared by all callers (the running script via execute and
+    # openc3cli when constructing options) so the contract lives in one place.
+    # Suite/Group existence is checked in execute since it needs @@suites.
+    def self.validate_options(group: nil, script: nil)
+      raise ArgumentError, "Script #{script} requires a Group" if script and not group
+    end
+
+    # Build the canonical, validated suite_runner hash from raw values,
+    # applying defaults. Shared by openc3cli (constructing from CLI flags) and
+    # the running script (normalizing a received hash before dispatch) so the
+    # hash shape, defaults, and validation live in one place.
+    def self.build_options(suite:, group: nil, script: nil, method: nil, options: nil)
+      validate_options(group: group, script: script)
+      suite_runner = { 'suite' => suite }
+      if group
+        suite_runner['group'] = group
+        suite_runner['script'] = script if script
+      end
+      # A script always runs via start, matching the GUI
+      suite_runner['method'] = script ? DEFAULT_METHOD : (method || DEFAULT_METHOD)
+      suite_runner['options'] = options || DEFAULT_OPTIONS.dup
+      suite_runner
+    end
+
     def self.execute(result_string, suite_class, group_class = nil, script = nil)
       @@suite_results = SuiteResults.new
       # Surface invalid suite / group / option combinations rather than
       # silently running nothing or failing with an opaque nil error. An
       # invalid script method raises later in Group#run_method.
-      raise ArgumentError, "Script #{script} requires a Group" if script and not group_class
+      validate_options(group: group_class, script: script)
       suite = @@suites.find { |s| s.class == suite_class }
       raise ArgumentError, "Suite #{suite_class} not found" unless suite
       if group_class and not suite.scripts.key?(group_class)

--- a/openc3/lib/openc3/script/suite_runner.rb
+++ b/openc3/lib/openc3/script/suite_runner.rb
@@ -44,15 +44,19 @@ module OpenC3
 
     def self.execute(result_string, suite_class, group_class = nil, script = nil)
       @@suite_results = SuiteResults.new
-      @@suites.each do |suite|
-        if suite.class == suite_class
-          @@suite_results.start(result_string, suite_class, group_class, script, @@settings)
-          loop do
-            yield(suite)
-            break if not @@settings['Loop'] or (ScriptStatus.instance.fail_count > 0 and @@settings['Break Loop On Error'])
-          end
-          break
-        end
+      # Surface invalid suite / group / option combinations rather than
+      # silently running nothing or failing with an opaque nil error. An
+      # invalid script method raises later in Group#run_method.
+      raise "Script #{script} requires a Group" if script and not group_class
+      suite = @@suites.find { |s| s.class == suite_class }
+      raise "Suite #{suite_class} not found" unless suite
+      if group_class and not suite.scripts.key?(group_class)
+        raise "Group #{group_class} not found in Suite #{suite_class}"
+      end
+      @@suite_results.start(result_string, suite_class, group_class, script, @@settings)
+      loop do
+        yield(suite)
+        break if not @@settings['Loop'] or (ScriptStatus.instance.fail_count > 0 and @@settings['Break Loop On Error'])
       end
     end
 

--- a/openc3/lib/openc3/utilities/running_script.rb
+++ b/openc3/lib/openc3/utilities/running_script.rb
@@ -827,17 +827,22 @@ class RunningScript
 
   def run
     if @script_status.suite_runner
-      if @script_status.suite_runner['options']
-        parse_options(@script_status.suite_runner['options'])
+      # Normalize the received hash through the shared helper so options/method
+      # defaults and validation match what openc3cli and the GUI construct.
+      sr = OpenC3::SuiteRunner.build_options(
+        suite: @script_status.suite_runner['suite'],
+        group: @script_status.suite_runner['group'],
+        script: @script_status.suite_runner['script'],
+        method: @script_status.suite_runner['method'],
+        options: @script_status.suite_runner['options'],
+      )
+      parse_options(sr['options'])
+      if sr['script']
+        run_text("OpenC3::SuiteRunner.start(#{sr['suite']}, #{sr['group']}, '#{sr['script']}')", initial_filename: "SCRIPTRUNNER")
+      elsif sr['group']
+        run_text("OpenC3::SuiteRunner.#{sr['method']}(#{sr['suite']}, #{sr['group']})", initial_filename: "SCRIPTRUNNER")
       else
-        parse_options({}) # Set default options
-      end
-      if @script_status.suite_runner['script']
-        run_text("OpenC3::SuiteRunner.start(#{@script_status.suite_runner['suite']}, #{@script_status.suite_runner['group']}, '#{@script_status.suite_runner['script']}')", initial_filename: "SCRIPTRUNNER")
-      elsif script_status.suite_runner['group']
-        run_text("OpenC3::SuiteRunner.#{@script_status.suite_runner['method']}(#{@script_status.suite_runner['suite']}, #{@script_status.suite_runner['group']})", initial_filename: "SCRIPTRUNNER")
-      else
-        run_text("OpenC3::SuiteRunner.#{@script_status.suite_runner['method']}(#{@script_status.suite_runner['suite']})", initial_filename: "SCRIPTRUNNER")
+        run_text("OpenC3::SuiteRunner.#{sr['method']}(#{sr['suite']})", initial_filename: "SCRIPTRUNNER")
       end
     else
       if not @script_engine and (@script_status.start_line_no != 1 or !@script_status.end_line_no.nil?)

--- a/openc3/lib/openc3/utilities/script.rb
+++ b/openc3/lib/openc3/utilities/script.rb
@@ -203,6 +203,10 @@ class Script < OpenC3::TargetFile
     line_no = nil,
     end_line_no = nil
   )
+    # Verify the script exists before spawning a run. Without this check a run
+    # is started and the missing file only surfaces as a runtime error inside
+    # the spawned process. Returning nil lets the caller return a 404.
+    return nil unless Script.body(scope, name)
     RunningScript.spawn(scope, name, suite_runner, disconnect, environment, user_full_name, username, line_no, end_line_no)
   end
 

--- a/openc3/python/openc3/script/script_runner.py
+++ b/openc3/python/openc3/script/script_runner.py
@@ -17,7 +17,10 @@ from openc3.utilities.extract import *
 
 
 def _script_response_error(response, message, scope=OPENC3_SCOPE):
-    if response:
+    # NOTE: check identity not truthiness - requests.Response is falsy for any
+    # non-2xx status (Response.__bool__ returns self.ok), which would otherwise
+    # report an error response (e.g. 404) as "No Response" and discard the body.
+    if response is not None:
         raise RuntimeError(f"{message} ({response.status_code}): {response.text}")
     else:
         raise RuntimeError(f"{message}: No Response")

--- a/openc3/python/openc3/script/suite_runner.py
+++ b/openc3/python/openc3/script/suite_runner.py
@@ -36,12 +36,12 @@ class SuiteRunner:
         # silently running nothing or failing with an opaque error. An
         # invalid script method raises later in Group.run_method.
         if script and not group_class:
-            raise RuntimeError(f"Script {script} requires a Group")
+            raise ValueError(f"Script {script} requires a Group")
         suite = next((s for s in SuiteRunner.suites if s.__class__ == suite_class), None)
         if not suite:
-            raise RuntimeError(f"Suite {suite_class} not found")
+            raise ValueError(f"Suite {suite_class} not found")
         if group_class and group_class not in suite.scripts():
-            raise RuntimeError(f"Group {group_class} not found in Suite {suite_class}")
+            raise ValueError(f"Group {group_class} not found in Suite {suite_class}")
         SuiteRunner.suite_results.start(
             result_string,
             suite_class,

--- a/openc3/python/openc3/script/suite_runner.py
+++ b/openc3/python/openc3/script/suite_runner.py
@@ -25,9 +25,38 @@ class UnassignedSuite(Suite):
 
 
 class SuiteRunner:
+    # Default suite_runner options shared by all callers so the values stay
+    # consistent in one place.
+    DEFAULT_METHOD = "start"
+    DEFAULT_OPTIONS = ["continueAfterError"]
+
     suites = []
     settings = {}
     suite_results = None
+
+    # Validate the suite_runner option combinations that don't require the
+    # built suites. Shared by all callers so the contract lives in one place.
+    # Suite/Group existence is checked in execute since it needs the suites.
+    @classmethod
+    def validate_options(cls, group=None, script=None):
+        if script and not group:
+            raise ValueError(f"Script {script} requires a Group")
+
+    # Build the canonical, validated suite_runner dict from raw values, applying
+    # defaults. Shared so the dict shape, defaults, and validation live in one
+    # place (used by the running script when normalizing a received dict).
+    @classmethod
+    def build_options(cls, suite, group=None, script=None, method=None, options=None):
+        cls.validate_options(group=group, script=script)
+        suite_runner = {"suite": suite}
+        if group:
+            suite_runner["group"] = group
+            if script:
+                suite_runner["script"] = script
+        # A script always runs via start, matching the GUI
+        suite_runner["method"] = cls.DEFAULT_METHOD if script else (method or cls.DEFAULT_METHOD)
+        suite_runner["options"] = options if options is not None else list(cls.DEFAULT_OPTIONS)
+        return suite_runner
 
     @classmethod
     def execute(cls, result_string, suite_class, group_class=None, script=None):
@@ -35,8 +64,7 @@ class SuiteRunner:
         # Surface invalid suite / group / option combinations rather than
         # silently running nothing or failing with an opaque error. An
         # invalid script method raises later in Group.run_method.
-        if script and not group_class:
-            raise ValueError(f"Script {script} requires a Group")
+        cls.validate_options(group=group_class, script=script)
         suite = next((s for s in SuiteRunner.suites if s.__class__ == suite_class), None)
         if not suite:
             raise ValueError(f"Suite {suite_class} not found")

--- a/openc3/python/openc3/script/suite_runner.py
+++ b/openc3/python/openc3/script/suite_runner.py
@@ -32,21 +32,28 @@ class SuiteRunner:
     @classmethod
     def execute(cls, result_string, suite_class, group_class=None, script=None):
         SuiteRunner.suite_results = SuiteResults()
-        for suite in SuiteRunner.suites:
-            if suite.__class__ == suite_class:
-                SuiteRunner.suite_results.start(
-                    result_string,
-                    suite_class,
-                    group_class,
-                    script,
-                    SuiteRunner.settings,
-                )
-                while True:
-                    yield (suite)
-                    if not SuiteRunner.settings["Loop"] or (
-                        ScriptStatus.instance().fail_count > 0 and SuiteRunner.settings["Break Loop On Error"]
-                    ):
-                        break
+        # Surface invalid suite / group / option combinations rather than
+        # silently running nothing or failing with an opaque error. An
+        # invalid script method raises later in Group.run_method.
+        if script and not group_class:
+            raise RuntimeError(f"Script {script} requires a Group")
+        suite = next((s for s in SuiteRunner.suites if s.__class__ == suite_class), None)
+        if not suite:
+            raise RuntimeError(f"Suite {suite_class} not found")
+        if group_class and group_class not in suite.scripts():
+            raise RuntimeError(f"Group {group_class} not found in Suite {suite_class}")
+        SuiteRunner.suite_results.start(
+            result_string,
+            suite_class,
+            group_class,
+            script,
+            SuiteRunner.settings,
+        )
+        while True:
+            yield (suite)
+            if not SuiteRunner.settings["Loop"] or (
+                ScriptStatus.instance().fail_count > 0 and SuiteRunner.settings["Break Loop On Error"]
+            ):
                 break
 
     @classmethod

--- a/openc3/python/openc3/utilities/running_script.py
+++ b/openc3/python/openc3/utilities/running_script.py
@@ -527,23 +527,29 @@ class RunningScript:
 
     def run(self):
         if self.script_status.suite_runner is not None:
-            if "options" in self.script_status.suite_runner:
-                self.parse_options(self.script_status.suite_runner["options"])
-            else:
-                self.parse_options({})  # Set default options
-            if "script" in self.script_status.suite_runner:
+            # Normalize the received dict through the shared helper so options/
+            # method defaults and validation match what openc3cli and the GUI build.
+            sr = SuiteRunner.build_options(
+                suite=self.script_status.suite_runner.get("suite"),
+                group=self.script_status.suite_runner.get("group"),
+                script=self.script_status.suite_runner.get("script"),
+                method=self.script_status.suite_runner.get("method"),
+                options=self.script_status.suite_runner.get("options"),
+            )
+            self.parse_options(sr["options"])
+            if "script" in sr:
                 self.run_text(
-                    f"from openc3.script.suite_runner import SuiteRunner\nSuiteRunner.start({self.script_status.suite_runner['suite']}, {self.script_status.suite_runner['group']}, '{self.script_status.suite_runner['script']}')",
+                    f"from openc3.script.suite_runner import SuiteRunner\nSuiteRunner.start({sr['suite']}, {sr['group']}, '{sr['script']}')",
                     initial_filename="SCRIPTRUNNER",
                 )
-            elif "group" in self.script_status.suite_runner:
+            elif "group" in sr:
                 self.run_text(
-                    f"from openc3.script.suite_runner import SuiteRunner\nSuiteRunner.{self.script_status.suite_runner['method']}({self.script_status.suite_runner['suite']}, {self.script_status.suite_runner['group']})",
+                    f"from openc3.script.suite_runner import SuiteRunner\nSuiteRunner.{sr['method']}({sr['suite']}, {sr['group']})",
                     initial_filename="SCRIPTRUNNER",
                 )
             else:
                 self.run_text(
-                    f"from openc3.script.suite_runner import SuiteRunner\nSuiteRunner.{self.script_status.suite_runner['method']}({self.script_status.suite_runner['suite']})",
+                    f"from openc3.script.suite_runner import SuiteRunner\nSuiteRunner.{sr['method']}({sr['suite']})",
                     initial_filename="SCRIPTRUNNER",
                 )
         else:

--- a/openc3/python/test/script/test_suite_runner.py
+++ b/openc3/python/test/script/test_suite_runner.py
@@ -62,6 +62,7 @@ class MissingTeardownSuite(Suite):
 # OptionsSuite; OtherGroup is intentionally left out of any suite plan.
 class SuiteRunnerOptionsGroup(Group):
     def test_valid_script(self):
+        # Mock for testing, no implementation needed
         pass
 
 
@@ -72,6 +73,7 @@ class SuiteRunnerOptionsSuite(Suite):
 
 class SuiteRunnerOtherGroup(Group):
     def test_other(self):
+        # Mock for testing, no implementation needed
         pass
 
 
@@ -126,17 +128,17 @@ class TestSuiteRunner(unittest.TestCase):
 
     def test_start_raises_when_script_given_without_group(self):
         self._build_options_suite()
-        with self.assertRaisesRegex(RuntimeError, "Script test_valid_script requires a Group"):
+        with self.assertRaisesRegex(ValueError, "Script test_valid_script requires a Group"):
             SuiteRunner.start(SuiteRunnerOptionsSuite, None, "test_valid_script")
 
     def test_start_raises_for_unknown_suite(self):
         self._build_options_suite()
-        with self.assertRaisesRegex(RuntimeError, "Suite .* not found"):
+        with self.assertRaisesRegex(ValueError, "Suite .* not found"):
             SuiteRunner.start(str)
 
     def test_start_raises_for_group_not_in_suite(self):
         self._build_options_suite()
-        with self.assertRaisesRegex(RuntimeError, "Group .* not found in Suite"):
+        with self.assertRaisesRegex(ValueError, "Group .* not found in Suite"):
             SuiteRunner.start(SuiteRunnerOptionsSuite, SuiteRunnerOtherGroup)
 
 

--- a/openc3/python/test/script/test_suite_runner.py
+++ b/openc3/python/test/script/test_suite_runner.py
@@ -141,6 +141,44 @@ class TestSuiteRunner(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Group .* not found in Suite"):
             SuiteRunner.start(SuiteRunnerOptionsSuite, SuiteRunnerOtherGroup)
 
+    def test_build_options_applies_defaults_when_omitted(self):
+        self.assertEqual(
+            SuiteRunner.build_options(suite="MySuite", group="MyGroup"),
+            {"suite": "MySuite", "group": "MyGroup", "method": "start", "options": ["continueAfterError"]},
+        )
+
+    def test_build_options_uses_provided_method_and_options(self):
+        self.assertEqual(
+            SuiteRunner.build_options(suite="MySuite", group="MyGroup", method="teardown", options=["manual"]),
+            {"suite": "MySuite", "group": "MyGroup", "method": "teardown", "options": ["manual"]},
+        )
+
+    def test_build_options_nests_script_and_forces_start(self):
+        self.assertEqual(
+            SuiteRunner.build_options(suite="MySuite", group="MyGroup", script="test_foo", method="teardown"),
+            {
+                "suite": "MySuite",
+                "group": "MyGroup",
+                "script": "test_foo",
+                "method": "start",
+                "options": ["continueAfterError"],
+            },
+        )
+
+    def test_build_options_omits_group_and_script_without_group(self):
+        self.assertEqual(
+            SuiteRunner.build_options(suite="MySuite"),
+            {"suite": "MySuite", "method": "start", "options": ["continueAfterError"]},
+        )
+
+    def test_build_options_raises_when_script_given_without_group(self):
+        with self.assertRaisesRegex(ValueError, "Script test_foo requires a Group"):
+            SuiteRunner.build_options(suite="MySuite", script="test_foo")
+
+    def test_build_options_returns_copy_of_default_options(self):
+        result = SuiteRunner.build_options(suite="MySuite")
+        self.assertIsNot(result["options"], SuiteRunner.DEFAULT_OPTIONS)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openc3/python/test/script/test_suite_runner.py
+++ b/openc3/python/test/script/test_suite_runner.py
@@ -58,6 +58,23 @@ class MissingTeardownSuite(Suite):
         self.add_group_teardown(NoSetupTeardownGroup)
 
 
+# Fixtures for SuiteRunner option validation. OptionsGroup is part of
+# OptionsSuite; OtherGroup is intentionally left out of any suite plan.
+class SuiteRunnerOptionsGroup(Group):
+    def test_valid_script(self):
+        pass
+
+
+class SuiteRunnerOptionsSuite(Suite):
+    def __init__(self):
+        self.add_group(SuiteRunnerOptionsGroup)
+
+
+class SuiteRunnerOtherGroup(Group):
+    def test_other(self):
+        pass
+
+
 class TestSuiteRunner(unittest.TestCase):
     def test_build_suites_creates_a_list_of_suites(self):
         mod = types.ModuleType("test_mod")
@@ -97,6 +114,30 @@ class TestSuiteRunner(unittest.TestCase):
         mod.MissingTeardownSuite = MissingTeardownSuite
         with self.assertRaises(AttributeError, msg="teardown"):
             SuiteRunner.build_suites(from_module=mod)
+
+    # These validate the suite_runner option combinations that flow through
+    # RunningScript.run into SuiteRunner.start / setup / teardown (all of
+    # which funnel through SuiteRunner.execute).
+    def _build_options_suite(self):
+        mod = types.ModuleType("test_mod")
+        mod.SuiteRunnerOptionsGroup = SuiteRunnerOptionsGroup
+        mod.SuiteRunnerOptionsSuite = SuiteRunnerOptionsSuite
+        SuiteRunner.build_suites(from_module=mod)
+
+    def test_start_raises_when_script_given_without_group(self):
+        self._build_options_suite()
+        with self.assertRaisesRegex(RuntimeError, "Script test_valid_script requires a Group"):
+            SuiteRunner.start(SuiteRunnerOptionsSuite, None, "test_valid_script")
+
+    def test_start_raises_for_unknown_suite(self):
+        self._build_options_suite()
+        with self.assertRaisesRegex(RuntimeError, "Suite .* not found"):
+            SuiteRunner.start(str)
+
+    def test_start_raises_for_group_not_in_suite(self):
+        self._build_options_suite()
+        with self.assertRaisesRegex(RuntimeError, "Group .* not found in Suite"):
+            SuiteRunner.start(SuiteRunnerOptionsSuite, SuiteRunnerOtherGroup)
 
 
 if __name__ == "__main__":

--- a/openc3/python/uv.lock
+++ b/openc3/python/uv.lock
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "openc3"
-version = "7.1.2b0"
+version = "7.2.1b0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/openc3/spec/script/suite_runner_spec.rb
+++ b/openc3/spec/script/suite_runner_spec.rb
@@ -116,5 +116,45 @@ module OpenC3
           .to raise_error(/Group SuiteRunnerOtherGroup not found in Suite SuiteRunnerOptionsSuite/)
       end
     end
+
+    describe "self.build_options" do
+      it "applies default method and options when omitted" do
+        expect(SuiteRunner.build_options(suite: 'MySuite', group: 'MyGroup')).to eq(
+          'suite' => 'MySuite', 'group' => 'MyGroup',
+          'method' => 'start', 'options' => ['continueAfterError']
+        )
+      end
+
+      it "uses the provided method and options" do
+        expect(SuiteRunner.build_options(suite: 'MySuite', group: 'MyGroup', method: 'teardown', options: ['manual'])).to eq(
+          'suite' => 'MySuite', 'group' => 'MyGroup',
+          'method' => 'teardown', 'options' => ['manual']
+        )
+      end
+
+      it "nests script under group and forces method to start" do
+        expect(SuiteRunner.build_options(suite: 'MySuite', group: 'MyGroup', script: 'test_foo', method: 'teardown')).to eq(
+          'suite' => 'MySuite', 'group' => 'MyGroup', 'script' => 'test_foo',
+          'method' => 'start', 'options' => ['continueAfterError']
+        )
+      end
+
+      it "omits group and script when no group is given" do
+        expect(SuiteRunner.build_options(suite: 'MySuite')).to eq(
+          'suite' => 'MySuite', 'method' => 'start', 'options' => ['continueAfterError']
+        )
+      end
+
+      it "raises when a script is given without a group" do
+        expect { SuiteRunner.build_options(suite: 'MySuite', script: 'test_foo') }
+          .to raise_error(/Script test_foo requires a Group/)
+      end
+
+      it "returns a mutable copy of the default options" do
+        result = SuiteRunner.build_options(suite: 'MySuite')
+        expect(result['options']).to_not be_frozen
+        expect(result['options']).to_not equal(SuiteRunner::DEFAULT_OPTIONS)
+      end
+    end
   end
 end

--- a/openc3/spec/script/suite_runner_spec.rb
+++ b/openc3/spec/script/suite_runner_spec.rb
@@ -15,6 +15,22 @@ require 'spec_helper'
 require 'openc3/script/suite'
 require 'openc3/script/suite_runner'
 
+# Fixtures for exercising SuiteRunner option validation. OptionsGroup is part
+# of OptionsSuite; OtherGroup is intentionally left out of any suite plan.
+class SuiteRunnerOptionsGroup < OpenC3::Group
+  def test_valid_script
+  end
+end
+class SuiteRunnerOptionsSuite < OpenC3::Suite
+  def initialize
+    add_group('SuiteRunnerOptionsGroup')
+  end
+end
+class SuiteRunnerOtherGroup < OpenC3::Group
+  def test_other
+  end
+end
+
 module OpenC3
   describe SuiteRunner do
     describe "self.build_suites" do
@@ -73,6 +89,29 @@ module OpenC3
         expect(suites.keys).to include "OrderedSuite"
         # Scripts should be in the order they were added, not alphabetical
         expect(suites["OrderedSuite"][:groups]["OrderedGroup"][:scripts]).to eql %w(test_m_middle test_z_last test_a_first)
+      end
+    end
+
+    # These validate the suite_runner option combinations that flow through
+    # RunningScript#run into SuiteRunner.start / setup / teardown (all of
+    # which funnel through SuiteRunner.execute).
+    describe "self.start option validation" do
+      before(:each) do
+        SuiteRunner.build_suites
+      end
+
+      it "raises when a script is given without a group" do
+        expect { SuiteRunner.start(SuiteRunnerOptionsSuite, nil, 'test_valid_script') }
+          .to raise_error(/Script test_valid_script requires a Group/)
+      end
+
+      it "raises for an unknown suite" do
+        expect { SuiteRunner.start(String) }.to raise_error(/Suite String not found/)
+      end
+
+      it "raises for a group not in the suite" do
+        expect { SuiteRunner.start(SuiteRunnerOptionsSuite, SuiteRunnerOtherGroup) }
+          .to raise_error(/Group SuiteRunnerOtherGroup not found in Suite SuiteRunnerOptionsSuite/)
       end
     end
   end

--- a/openc3/spec/script/suite_runner_spec.rb
+++ b/openc3/spec/script/suite_runner_spec.rb
@@ -19,6 +19,7 @@ require 'openc3/script/suite_runner'
 # of OptionsSuite; OtherGroup is intentionally left out of any suite plan.
 class SuiteRunnerOptionsGroup < OpenC3::Group
   def test_valid_script
+    # Mock for testing, no implementation needed
   end
 end
 class SuiteRunnerOptionsSuite < OpenC3::Suite
@@ -28,6 +29,7 @@ class SuiteRunnerOptionsSuite < OpenC3::Suite
 end
 class SuiteRunnerOtherGroup < OpenC3::Group
   def test_other
+    # Mock for testing, no implementation needed
   end
 end
 


### PR DESCRIPTION
- clarified `script_run` description
- added table for `suite_runner` parameter options, in the same way as `create_timeline_activity`
- ensure errors are passed through
- throw an error, instead of spawning a thread that will crash, if `script_run` is provided a file name that does not exist
- parameter verification for `script_run`'s `suite_runner` parameter
- additional Claude context for running Rails tests
- align `running_script.rb`/`running_script.py` and `openc3cli`