### PR TITLE
fix(plugin_model): prevent OS command injection via pypi_url setting

### DIFF
--- a/openc3/lib/openc3/models/plugin_model.rb
+++ b/openc3/lib/openc3/models/plugin_model.rb
@@ -31,9 +31,11 @@ require 'openc3/models/tool_model'
 require 'openc3/models/widget_model'
 require 'openc3/models/microservice_model'
 require 'openc3/api/api'
+require 'openc3/utilities/pypi_url'
 require 'tmpdir'
 require 'tempfile'
 require 'fileutils'
+require 'open3'
 
 module OpenC3
   class EmptyGemFileError < StandardError; end
@@ -262,32 +264,31 @@ module OpenC3
               if pypi_url
                 pypi_url += '/simple'
               end
-              pypi_url ||= 'https://pypi.org/simple'
+              pypi_url ||= PypiUrl::DEFAULT
             end
           end
+          pypi_url = PypiUrl.validate(pypi_url)
           unless validate_only
+            # Build the pip arguments as an argv array and run pipinstall without a
+            # shell. pypi_url comes from a user-writable setting, so interpolating it
+            # into a shell command line allowed OS command injection. An argv array
+            # passes each argument verbatim with no shell metacharacter interpretation.
+            pip_args = ["-i", pypi_url]
+            pip_args += ["--trusted-host", URI.parse(pypi_url).host] unless ENV['PIP_ENABLE_TRUSTED_HOST'].nil?
             if File.exist?(pyproject_path)
               Logger.info "Installing python packages from pyproject.toml with pypi_url=#{pypi_url}"
-              if ENV['PIP_ENABLE_TRUSTED_HOST'].nil?
-                pip_args = "-i #{pypi_url} #{gem_path}"
-              else
-                pip_args = "-i #{pypi_url} --trusted-host #{URI.parse(pypi_url).host} #{gem_path}"
-              end
+              pip_args << gem_path
             else
               Logger.info "Installing python packages from requirements.txt with pypi_url=#{pypi_url}"
-              if ENV['PIP_ENABLE_TRUSTED_HOST'].nil?
-                pip_args = "-i #{pypi_url} -r #{requirements_path}"
-              else
-                pip_args = "-i #{pypi_url} --trusted-host #{URI.parse(pypi_url).host} -r #{requirements_path}"
-              end
+              pip_args += ["-r", requirements_path]
             end
             # Capture output and check exit code so failures surface as a warning
             # rather than silently succeeding. pipinstall is non-fatal: the plugin
             # continues to install even if Python packages fail so that non-Python
             # functionality still works.
-            output = `/openc3/bin/pipinstall #{pip_args}`
+            output, status = Open3.capture2e("/openc3/bin/pipinstall", *pip_args)
             puts output
-            unless $?.success?
+            unless status.success?
               Logger.warn "Python package installation failed. Plugin Python microservices may not function correctly."
             end
           end

--- a/openc3/lib/openc3/models/python_package_model.rb
+++ b/openc3/lib/openc3/models/python_package_model.rb
@@ -13,6 +13,7 @@
 
 require 'fileutils'
 require 'openc3/utilities/process_manager'
+require 'openc3/utilities/pypi_url'
 require 'openc3/api/api'
 require 'pathname'
 
@@ -83,9 +84,10 @@ module OpenC3
           if pypi_url
             pypi_url += '/simple'
           end
-          pypi_url ||= 'https://pypi.org/simple'
+          pypi_url ||= PypiUrl::DEFAULT
         end
       end
+      pypi_url = PypiUrl.validate(pypi_url)
       Logger.info "Installing python package: #{name_or_path}"
       if ENV['PIP_ENABLE_TRUSTED_HOST'].nil?
         pip_args = ["-i", pypi_url, package_file_path]

--- a/openc3/lib/openc3/utilities/pypi_url.rb
+++ b/openc3/lib/openc3/utilities/pypi_url.rb
@@ -1,0 +1,39 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+require 'uri'
+require 'openc3/utilities/logger'
+
+module OpenC3
+  class PypiUrl
+    DEFAULT = 'https://pypi.org/simple'
+
+    # Validate that a resolved pypi_url is an http(s) URL before it is handed to
+    # pip. The value can come from a user-writable setting or ENV, so a malformed
+    # or non-http value is rejected and replaced with the default rather than
+    # passed through to pip.
+    #
+    # @param pypi_url [String] the resolved pypi index url to validate
+    # @return [String] the original url if valid, otherwise DEFAULT
+    def self.validate(pypi_url)
+      uri = URI.parse(pypi_url)
+      unless uri.is_a?(URI::HTTP) && !uri.host.to_s.empty?
+        raise URI::InvalidURIError, "not an http(s) URL"
+      end
+      pypi_url
+    rescue URI::InvalidURIError => e
+      Logger.error("Invalid pypi_url '#{pypi_url}' (#{e.message}); falling back to #{DEFAULT}")
+      DEFAULT
+    end
+  end
+end

--- a/openc3/spec/utilities/pypi_url_spec.rb
+++ b/openc3/spec/utilities/pypi_url_spec.rb
@@ -1,0 +1,78 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+require "spec_helper"
+require "openc3/utilities/pypi_url"
+
+module OpenC3
+  describe PypiUrl do
+    describe ".validate" do
+      context "with a valid http(s) url" do
+        it "returns https urls unchanged" do
+          url = "https://pypi.org/simple"
+          expect(PypiUrl.validate(url)).to eql url
+        end
+
+        it "returns http urls unchanged" do
+          url = "http://pypi.example.com/simple"
+          expect(PypiUrl.validate(url)).to eql url
+        end
+
+        it "allows a host with a port" do
+          url = "http://localhost:8080/simple"
+          expect(PypiUrl.validate(url)).to eql url
+        end
+
+        it "does not log an error" do
+          expect(Logger).to_not receive(:error)
+          PypiUrl.validate("https://pypi.org/simple")
+        end
+      end
+
+      context "with an invalid url" do
+        # Shell metacharacters that previously enabled command injection
+        it "rejects a value containing shell metacharacters" do
+          expect(Logger).to receive(:error)
+          payload = "https://pypi.org ; id > /tmp/PWNED ; #"
+          expect(PypiUrl.validate(payload)).to eql PypiUrl::DEFAULT
+        end
+
+        it "rejects a non-http(s) scheme" do
+          expect(Logger).to receive(:error)
+          expect(PypiUrl.validate("ftp://example.com/simple")).to eql PypiUrl::DEFAULT
+        end
+
+        it "rejects a url with no host" do
+          expect(Logger).to receive(:error)
+          expect(PypiUrl.validate("https:///simple")).to eql PypiUrl::DEFAULT
+        end
+
+        it "rejects a value that is not a url" do
+          expect(Logger).to receive(:error)
+          expect(PypiUrl.validate("not a url")).to eql PypiUrl::DEFAULT
+        end
+
+        it "rejects an empty string" do
+          expect(Logger).to receive(:error)
+          expect(PypiUrl.validate("")).to eql PypiUrl::DEFAULT
+        end
+      end
+    end
+
+    describe "DEFAULT" do
+      it "is the public pypi simple index" do
+        expect(PypiUrl::DEFAULT).to eql "https://pypi.org/simple"
+      end
+    end
+  end
+end


### PR DESCRIPTION
PluginModel.install_phase2 interpolated the user-writable pypi_url setting into a shell command run through a backtick, allowing arbitrary OS command execution during plugin install. Run pipinstall via an argv array with Open3.capture2e (no shell) and validate pypi_url is an http(s) URL at use-time, falling back to the default on a bad value. Add a shared PypiUrl utility and spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)