### PR TITLE
revert vuetify back to v3

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/package.json
@@ -16,7 +16,7 @@
     "date-fns": "4.3.0",
     "import-map-overrides": "6.1.0",
     "systemjs": "6.15.1",
-    "vuetify": "4.0.7"
+    "vuetify": "3.12.2"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-systemjs": "7.29.7",

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/package.json
@@ -92,7 +92,7 @@
     "sprintf-js": "1.1.3",
     "uplot": "1.6.32",
     "vue": "3.5.35",
-    "vuetify": "4.0.7"
+    "vuetify": "3.12.2"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "6.0.7",

--- a/openc3-cosmos-init/plugins/pnpm-lock.yaml
+++ b/openc3-cosmos-init/plugins/pnpm-lock.yaml
@@ -772,8 +772,8 @@ importers:
         specifier: 4.4.4
         version: 4.4.4(vue@3.5.35)
       vuetify:
-        specifier: 4.0.7
-        version: 4.0.7(vue@3.5.35)
+        specifier: 3.12.2
+        version: 3.12.2(vue@3.5.35)
     devDependencies:
       '@babel/plugin-transform-modules-systemjs':
         specifier: 7.29.7
@@ -860,8 +860,8 @@ importers:
         specifier: 3.5.35
         version: 3.5.35
       vuetify:
-        specifier: 4.0.7
-        version: 4.0.7(vue@3.5.35)
+        specifier: 3.12.2
+        version: 3.12.2(vue@3.5.35)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
@@ -2405,6 +2405,21 @@ packages:
       typescript:
         optional: true
 
+  vuetify@3.12.2:
+    resolution: {integrity: sha512-cVQa4+5iQpDs00ToMUnWRHlMdv1d5tEH2wcZIthqSCmBipQAG4rQKE55zFwZFYlPyiDhUVY1RcAFtXCuHNcCww==}
+    peerDependencies:
+      typescript: '>=4.7'
+      vite-plugin-vuetify: '>=2.1.0'
+      vue: ^3.5.0
+      webpack-plugin-vuetify: '>=3.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      vite-plugin-vuetify:
+        optional: true
+      webpack-plugin-vuetify:
+        optional: true
+
   vuetify@4.0.7:
     resolution: {integrity: sha512-SV+YJkBmudY3s9qfZO2ZGUsrD0TDQU8pMBH1ERga9AEyjGvioZuXXh93V9wHxXJphvqRC2NW10Nt2lW9IZQcPw==}
     peerDependencies:
@@ -3796,6 +3811,10 @@ snapshots:
       '@vue/runtime-dom': 3.5.35
       '@vue/server-renderer': 3.5.35(vue@3.5.35)
       '@vue/shared': 3.5.35
+
+  vuetify@3.12.2(vue@3.5.35):
+    dependencies:
+      vue: 3.5.35
 
   vuetify@4.0.7(vue@3.5.35):
     dependencies:


### PR DESCRIPTION
Upgrading Vuetify to v4 will require a significant amount of work and has a dedicated [issue](https://github.com/OpenC3/cosmos/issues/2915) planned to be completed for COSMOS 8.

This upgrade was accidentally included in a [previous PR](https://github.com/OpenC3/cosmos/pull/3421) as part of using `package_audit.rb`