### PR TITLE
[Bug] Fix race condition in interface model cancel thread

### DIFF
--- a/openc3/lib/openc3/microservices/interface_microservice.rb
+++ b/openc3/lib/openc3/microservices/interface_microservice.rb
@@ -855,7 +855,8 @@ module OpenC3
 
       # If the interface is set to auto_reconnect then delay so the thread
       # can come back around and allow the interface a chance to reconnect.
-      if allow_reconnect and @interface.auto_reconnect and @interface.state != 'DISCONNECTED'
+      # Skip reconnect if stop() has been called to avoid re-creating the status model
+      if allow_reconnect and @interface.auto_reconnect and @interface.state != 'DISCONNECTED' and !@cancel_thread
         attempting()
         if !@cancel_thread
           # @logger.debug "reconnect delay: #{@interface.reconnect_delay}"
@@ -863,10 +864,12 @@ module OpenC3
         end
       else
         @interface.state = 'DISCONNECTED'
-        if @interface_or_router == 'INTERFACE'
-          InterfaceStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
-        else
-          RouterStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
+        unless @cancel_thread
+          if @interface_or_router == 'INTERFACE'
+            InterfaceStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
+          else
+            RouterStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
+          end
         end
       end
     end

--- a/openc3/lib/openc3/microservices/interface_microservice.rb
+++ b/openc3/lib/openc3/microservices/interface_microservice.rb
@@ -717,7 +717,8 @@ module OpenC3
     end
 
     def handle_packet(packet)
-      InterfaceStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
+      # Skip status update if stop() has been called to avoid re-creating the status model
+      InterfaceStatusModel.set(@interface.as_json(), queued: true, scope: @scope) unless @cancel_thread
       packet.received_time = Time.now.sys unless packet.received_time
 
       if packet.stored

--- a/openc3/lib/openc3/microservices/interface_microservice.rb
+++ b/openc3/lib/openc3/microservices/interface_microservice.rb
@@ -706,10 +706,12 @@ module OpenC3
         # Try to do clean disconnect because we're going down
         disconnect(false)
       end
-      if @interface_or_router == 'INTERFACE'
-        InterfaceStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
-      else
-        RouterStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
+      unless @cancel_thread
+        if @interface_or_router == 'INTERFACE'
+          InterfaceStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
+        else
+          RouterStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
+        end
       end
       @logger.info "#{@interface.name}: Stopped packet reading"
     end

--- a/openc3/lib/openc3/models/interface_model.rb
+++ b/openc3/lib/openc3/models/interface_model.rb
@@ -466,7 +466,7 @@ module OpenC3
         end
         status_model.destroy if status_model
       rescue Exception => error
-        Logger.error("Error destroying #{type.downcase} status model #{@name} in scope #{@scope} due to #{error}")
+        Logger.error("Error destroying #{type&.downcase || 'unknown'} status model #{@name} in scope #{@scope} due to #{error}")
       end
     end
 

--- a/openc3/lib/openc3/models/interface_model.rb
+++ b/openc3/lib/openc3/models/interface_model.rb
@@ -455,15 +455,19 @@ module OpenC3
         model.destroy
         ConfigTopic.write({ kind: 'deleted', type: type.downcase, name: @name, plugin: @plugin }, scope: @scope)
       end
-
-      if type == 'INTERFACE'
-        status_model = InterfaceStatusModel.get_model(name: @name, scope: @scope)
-      else
-        status_model = RouterStatusModel.get_model(name: @name, scope: @scope)
-      end
-      status_model.destroy if status_model
     rescue Exception => error
       Logger.error("Error undeploying interface/router model #{@name} in scope #{@scope} due to #{error}")
+    ensure
+      begin
+        if type == 'INTERFACE'
+          status_model = InterfaceStatusModel.get_model(name: @name, scope: @scope)
+        else
+          status_model = RouterStatusModel.get_model(name: @name, scope: @scope)
+        end
+        status_model.destroy if status_model
+      rescue Exception => error
+        Logger.error("Error destroying #{type.downcase} status model #{@name} in scope #{@scope} due to #{error}")
+      end
     end
 
     def unmap_target(target_name, cmd_only: false, tlm_only: false)

--- a/openc3/lib/openc3/models/interface_model.rb
+++ b/openc3/lib/openc3/models/interface_model.rb
@@ -444,9 +444,11 @@ module OpenC3
       microservice
     end
 
-    # Looks up the deployed MicroserviceModel and destroy the microservice model
-    # should should trigger the operator to kill the microservice that in turn
-    # will destroy the InterfaceStatusModel when a stop is called.
+    # Destroys the deployed MicroserviceModel which triggers the operator to kill
+    # the microservice. Also directly destroys the Interface/RouterStatusModel in
+    # an ensure block. The microservice stop() no longer recreates the status
+    # model once cancel_thread is set, so undeploy must clean it up itself to
+    # avoid leaving an orphaned status model behind.
     def undeploy
       type = self.class._get_type
       name = "#{@scope}__#{type}__#{@name}"

--- a/openc3/python/openc3/microservices/interface_microservice.py
+++ b/openc3/python/openc3/microservices/interface_microservice.py
@@ -788,7 +788,9 @@ class InterfaceMicroservice(Microservice):
         self.logger.info(f"{self.interface.name}: Stopped packet reading")
 
     def handle_packet(self, packet):
-        InterfaceStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
+        # Skip status update if stop() has been called to avoid re-creating the status model
+        if not self.cancel_thread:
+            InterfaceStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
         if packet.received_time is None:
             packet.received_time = datetime.now(timezone.utc)
 
@@ -928,7 +930,7 @@ class InterfaceMicroservice(Microservice):
             and not self.cancel_thread
         ):
             self.attempting()
-            if self.cancel_thread is not None:
+            if not self.cancel_thread:
                 self.interface_thread_sleeper.sleep(self.interface.reconnect_delay)
         else:
             self.interface.state = "DISCONNECTED"

--- a/openc3/python/openc3/microservices/interface_microservice.py
+++ b/openc3/python/openc3/microservices/interface_microservice.py
@@ -921,7 +921,12 @@ class InterfaceMicroservice(Microservice):
         # If the interface is set to auto_reconnect then delay so the thread
         # can come back around and allow the interface a chance to reconnect.
         # Skip reconnect if stop() has been called to avoid re-creating the status model
-        if allow_reconnect and self.interface.auto_reconnect and self.interface.state != "DISCONNECTED" and not self.cancel_thread:
+        if (
+            allow_reconnect
+            and self.interface.auto_reconnect
+            and self.interface.state != "DISCONNECTED"
+            and not self.cancel_thread
+        ):
             self.attempting()
             if self.cancel_thread is not None:
                 self.interface_thread_sleeper.sleep(self.interface.reconnect_delay)

--- a/openc3/python/openc3/microservices/interface_microservice.py
+++ b/openc3/python/openc3/microservices/interface_microservice.py
@@ -780,10 +780,11 @@ class InterfaceMicroservice(Microservice):
                 # handle_fatal_exception(error)
             # Try to do clean disconnect because we're going down
             self.disconnect(False)
-        if self.interface_or_router == "INTERFACE":
-            InterfaceStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
-        else:
-            RouterStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
+        if not self.cancel_thread:
+            if self.interface_or_router == "INTERFACE":
+                InterfaceStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
+            else:
+                RouterStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
         self.logger.info(f"{self.interface.name}: Stopped packet reading")
 
     def handle_packet(self, packet):

--- a/openc3/python/openc3/microservices/interface_microservice.py
+++ b/openc3/python/openc3/microservices/interface_microservice.py
@@ -920,16 +920,18 @@ class InterfaceMicroservice(Microservice):
 
         # If the interface is set to auto_reconnect then delay so the thread
         # can come back around and allow the interface a chance to reconnect.
-        if allow_reconnect and self.interface.auto_reconnect and self.interface.state != "DISCONNECTED":
+        # Skip reconnect if stop() has been called to avoid re-creating the status model
+        if allow_reconnect and self.interface.auto_reconnect and self.interface.state != "DISCONNECTED" and not self.cancel_thread:
             self.attempting()
             if self.cancel_thread is not None:
                 self.interface_thread_sleeper.sleep(self.interface.reconnect_delay)
         else:
             self.interface.state = "DISCONNECTED"
-            if self.interface_or_router == "INTERFACE":
-                InterfaceStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
-            else:
-                RouterStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
+            if not self.cancel_thread:
+                if self.interface_or_router == "INTERFACE":
+                    InterfaceStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
+                else:
+                    RouterStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
 
     # Disconnect from the interface and stop the thread
     def stop(self):

--- a/openc3/python/test/microservices/test_interface_microservice.py
+++ b/openc3/python/test/microservices/test_interface_microservice.py
@@ -583,6 +583,24 @@ class TestInterfaceMicroservice(unittest.TestCase):
         result = InterfaceStatusModel.get(name="INST_INT", scope="DEFAULT")
         self.assertIsNone(result)
 
+    def test_handle_packet_does_not_write_status_after_cancel_thread_set(self):
+        """A packet already buffered can be returned from read() after stop()
+        sets cancel_thread and destroys the status model. handle_packet() must
+        not re-create the status model in that window (orphaned model bug)."""
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        im.interface.connect()
+        packet = im.interface.read()
+        self.assertIsNotNone(packet)
+
+        # Simulate stop() having run: cancel_thread set, status model destroyed
+        im.cancel_thread = True
+        with patch.object(InterfaceStatusModel, "set") as mock_set:
+            im.handle_packet(packet)
+            mock_set.assert_not_called()
+
+        im.shutdown()
+        time.sleep(0.1)  # Allow threads to exit
+
     def test_supports_optimize_throughput_option_for_backward_compatibility(self):
         # Update the model to use OPTIMIZE_THROUGHPUT option (legacy name)
         model = InterfaceModel(

--- a/openc3/python/test/microservices/test_interface_microservice.py
+++ b/openc3/python/test/microservices/test_interface_microservice.py
@@ -557,6 +557,32 @@ class TestInterfaceMicroservice(unittest.TestCase):
         result = handler.process_cmd(topic, msg_id, full_msg_hash, None)
         self.assertIsNone(result)
 
+    def test_run_does_not_write_status_after_cancel_thread_set(self):
+        """When stop() sets cancel_thread, disconnect() and run() must not
+        write to the status model, avoiding re-creation after stop() deletes it."""
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        all_interfaces = InterfaceStatusModel.all(scope="DEFAULT")
+        self.assertEqual(all_interfaces["INST_INT"]["state"], "ATTEMPTING")
+
+        for _stdout in capture_io():
+            thread = threading.Thread(target=im.run)
+            thread.start()
+            time.sleep(0.1)
+            all_interfaces = InterfaceStatusModel.all(scope="DEFAULT")
+            self.assertEqual(all_interfaces["INST_INT"]["state"], "CONNECTED")
+
+            im.shutdown()
+            thread.join(timeout=5)
+
+        # After shutdown the status model should be gone because:
+        # 1. stop() destroyed it
+        # 2. disconnect() skips status writes when cancel_thread is set
+        # 3. run() skips its final status write when cancel_thread is set
+        # Note: We check the direct (non-queued) store since queued writes
+        # from handle_packet before stop() may still be in the queue.
+        result = InterfaceStatusModel.get(name="INST_INT", scope="DEFAULT")
+        self.assertIsNone(result)
+
     def test_supports_optimize_throughput_option_for_backward_compatibility(self):
         # Update the model to use OPTIMIZE_THROUGHPUT option (legacy name)
         model = InterfaceModel(

--- a/openc3/spec/microservices/interface_microservice_spec.rb
+++ b/openc3/spec/microservices/interface_microservice_spec.rb
@@ -192,6 +192,27 @@ module OpenC3
       end
     end
 
+    describe "handle_packet" do
+      it "does not write the status model after cancel_thread is set" do
+        # A packet already buffered can be returned from read() after stop()
+        # sets @cancel_thread and destroys the status model. handle_packet must
+        # not re-create the status model in that window (orphaned model bug).
+        im = InterfaceMicroservice.new("DEFAULT__INTERFACE__INST_INT")
+        interface = im.instance_variable_get(:@interface)
+        interface.connect
+        packet = interface.read
+        expect(packet).to_not be_nil
+
+        # Simulate stop() having run: @cancel_thread set, status model destroyed
+        im.instance_variable_set(:@cancel_thread, true)
+        expect(InterfaceStatusModel).to_not receive(:set)
+        im.send(:handle_packet, packet)
+
+        im.shutdown
+        sleep 0.1 # Allow threads to exit
+      end
+    end
+
     describe "run" do
       it "handles exceptions in connect" do
         $connect_raise = true

--- a/openc3/spec/models/interface_model_spec.rb
+++ b/openc3/spec/models/interface_model_spec.rb
@@ -17,6 +17,9 @@
 
 require 'spec_helper'
 require 'openc3/models/interface_model'
+require 'openc3/models/interface_status_model'
+require 'openc3/models/router_model'
+require 'openc3/models/router_status_model'
 
 module OpenC3
   describe InterfaceModel do
@@ -267,6 +270,67 @@ module OpenC3
         expect(config[0][1]['type']).to eql 'interface'
         expect(config[0][1]['name']).to eql 'TEST_INT'
         expect(config[0][1]['plugin']).to eql 'PLUG'
+      end
+
+      it "destroys the InterfaceStatusModel when no MicroserviceModel exists" do
+        model = InterfaceModel.new(name: "TEST_INT", scope: "DEFAULT", plugin: "PLUG")
+        model.create
+        # Create a status model entry (simulating a running interface that wrote status)
+        InterfaceStatusModel.set({ name: 'TEST_INT', state: 'CONNECTED' }, scope: 'DEFAULT')
+        expect(InterfaceStatusModel.get(name: 'TEST_INT', scope: 'DEFAULT')).to_not be_nil
+
+        # No MicroserviceModel exists (already destroyed by PluginModel.undeploy Phase A)
+        expect(MicroserviceModel).to receive(:get_model).and_return(nil)
+
+        model.undeploy
+
+        # The status model should still be cleaned up
+        expect(InterfaceStatusModel.get(name: 'TEST_INT', scope: 'DEFAULT')).to be_nil
+      end
+
+      it "destroys the InterfaceStatusModel even when MicroserviceModel.destroy raises" do
+        model = InterfaceModel.new(name: "TEST_INT", scope: "DEFAULT", plugin: "PLUG")
+        model.create
+        # Create a status model entry
+        InterfaceStatusModel.set({ name: 'TEST_INT', state: 'CONNECTED' }, scope: 'DEFAULT')
+        expect(InterfaceStatusModel.get(name: 'TEST_INT', scope: 'DEFAULT')).to_not be_nil
+
+        # MicroserviceModel.destroy raises an exception
+        umodel = double(MicroserviceModel)
+        expect(umodel).to receive(:destroy).and_raise(RuntimeError.new("destroy failed"))
+        expect(MicroserviceModel).to receive(:get_model).and_return(umodel)
+
+        model.undeploy
+
+        # The status model should still be cleaned up despite the exception
+        expect(InterfaceStatusModel.get(name: 'TEST_INT', scope: 'DEFAULT')).to be_nil
+      end
+
+      it "destroys the RouterStatusModel even when MicroserviceModel.destroy raises" do
+        model = RouterModel.new(name: "TEST_ROUTER", scope: "DEFAULT", plugin: "PLUG")
+        model.create
+        # Create a router status model entry
+        RouterStatusModel.set({ name: 'TEST_ROUTER', state: 'CONNECTED' }, scope: 'DEFAULT')
+        expect(RouterStatusModel.get(name: 'TEST_ROUTER', scope: 'DEFAULT')).to_not be_nil
+
+        # MicroserviceModel.destroy raises an exception
+        umodel = double(MicroserviceModel)
+        expect(umodel).to receive(:destroy).and_raise(RuntimeError.new("destroy failed"))
+        expect(MicroserviceModel).to receive(:get_model).and_return(umodel)
+
+        model.undeploy
+
+        # The router status model should still be cleaned up despite the exception
+        expect(RouterStatusModel.get(name: 'TEST_ROUTER', scope: 'DEFAULT')).to be_nil
+      end
+
+      it "does not raise when status model does not exist during undeploy" do
+        model = InterfaceModel.new(name: "TEST_INT", scope: "DEFAULT", plugin: "PLUG")
+        model.create
+        expect(MicroserviceModel).to receive(:get_model).and_return(nil)
+
+        # No status model exists -- undeploy should not raise
+        expect { model.undeploy }.to_not raise_error
       end
     end
 


### PR DESCRIPTION
When uninstalling a plugin, there was a race condition where `InterfaceStatusModel.set()` or `RouterStatusModel.set()` could be called during the last loop iteration, immediately after a different thread removed them. This resulted in orphaned data in valkey.

There was also an issue in interface_model.rb where we never called `.destroy()` on the model if we encountered an exception earlier in the block.