### PR TITLE
fix(openc3.sh): never fall back to podman-compose

### DIFF
--- a/openc3.bat
+++ b/openc3.bat
@@ -43,11 +43,12 @@ if not defined CONTAINER_CMD (
   exit /b 1
 )
 
-REM Detect compose command
+REM Detect compose command. Never fall back to podman-compose; COSMOS only
+REM supports docker-compose as the standalone compose tool, even under podman.
 set CONTAINER_COMPOSE_CMD=
 %CONTAINER_CMD% compose version >nul 2>&1 && set CONTAINER_COMPOSE_CMD=%CONTAINER_CMD% compose
 if not defined CONTAINER_COMPOSE_CMD (
-  where %CONTAINER_CMD%-compose >nul 2>&1 && set CONTAINER_COMPOSE_CMD=%CONTAINER_CMD%-compose
+  where docker-compose >nul 2>&1 && set CONTAINER_COMPOSE_CMD=docker-compose
 )
 if not defined CONTAINER_COMPOSE_CMD (
   echo No compose command found! 1>&2

--- a/openc3.sh
+++ b/openc3.sh
@@ -21,7 +21,9 @@ detect_container_runtime() {
   fi
 }
 
-# Detect the compose command. Tries "<runtime> compose" first, then "<runtime>-compose".
+# Detect the compose command. Tries "<runtime> compose" first, then "docker-compose".
+# Never falls back to "podman-compose" since COSMOS only supports docker-compose as the
+# standalone compose tool, even when the container runtime is podman.
 # Result is cached. Exports DOCKER_COMPOSE_COMMAND for backward compatibility with sub-scripts.
 detect_compose_cmd() {
   if [[ -n "$CONTAINER_COMPOSE_CMD" ]]; then
@@ -30,10 +32,10 @@ detect_compose_cmd() {
   detect_container_runtime
   if $CONTAINER_CMD compose version &> /dev/null; then
     CONTAINER_COMPOSE_CMD="$CONTAINER_CMD compose"
-  elif command -v "${CONTAINER_CMD}-compose" &> /dev/null; then
-    CONTAINER_COMPOSE_CMD="${CONTAINER_CMD}-compose"
+  elif command -v "docker-compose" &> /dev/null; then
+    CONTAINER_COMPOSE_CMD="docker-compose"
   else
-    echo "No compose command found! Install '$CONTAINER_CMD compose' or '${CONTAINER_CMD}-compose'." >&2
+    echo "No compose command found! Install '$CONTAINER_CMD compose' or 'docker-compose'." >&2
     exit 1
   fi
   export DOCKER_COMPOSE_COMMAND="$CONTAINER_COMPOSE_CMD"

--- a/scripts/linux/openc3_test.sh
+++ b/scripts/linux/openc3_test.sh
@@ -12,10 +12,12 @@ if [[ -z "$DOCKER_COMPOSE_COMMAND" ]]; then
     echo "Neither docker nor podman found!" >&2
     exit 1
   fi
+  # Never fall back to podman-compose; COSMOS only supports docker-compose as
+  # the standalone compose tool, even when the runtime is podman.
   if $_RUNTIME compose version &> /dev/null; then
     export DOCKER_COMPOSE_COMMAND="$_RUNTIME compose"
-  elif command -v "${_RUNTIME}-compose" &> /dev/null; then
-    export DOCKER_COMPOSE_COMMAND="${_RUNTIME}-compose"
+  elif command -v "docker-compose" &> /dev/null; then
+    export DOCKER_COMPOSE_COMMAND="docker-compose"
   else
     echo "No compose command found!" >&2
     exit 1


### PR DESCRIPTION
Fixes #3514

## Problem

`detect_compose_cmd()` in `openc3.sh`, `openc3.bat`, and `openc3_test.sh` built the standalone compose fallback as `${CONTAINER_CMD}-compose`. When the runtime was podman, this resolved to `podman-compose` — which COSMOS does not support.

## Fix

Hardcode the fallback to `docker-compose`. The preferred `$CONTAINER_CMD compose` subcommand path (e.g. `podman compose`) is unchanged; only the standalone-tool fallback and its error message were updated to never reference `podman-compose`.

## Testing

- `bash -n openc3.sh` — syntax OK
- Simulated podman runtime with no `podman compose` subcommand and `docker-compose` present → resolves to `docker-compose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)